### PR TITLE
feat: BaseEntity 추가

### DIFF
--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/user/domain/User.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/user/domain/User.kt
@@ -1,22 +1,9 @@
 package org.depromeet.clog.server.domain.user.domain
 
-import jakarta.persistence.*
-
-@Entity
-class User(
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+data class User(
     val id: Long? = null,
-
-    @Column(nullable = false, unique = true)
     val loginId: String,
-
     val name: String,
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     val provider: Provider,
-
-    @Column(nullable = false)
     var isDeleted: Boolean = false
 )

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/common/BaseEntity.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/common/BaseEntity.kt
@@ -1,0 +1,24 @@
+package org.depromeet.clog.server.infrastructure.common
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime = LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault())
+
+    @LastModifiedDate
+    @Column(name = "modified_at", nullable = false)
+    var modifiedAt: LocalDateTime = LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault())
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/user/UserEntity.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/user/UserEntity.kt
@@ -1,0 +1,45 @@
+package org.depromeet.clog.server.infrastructure.user
+
+import jakarta.persistence.*
+import org.depromeet.clog.server.domain.user.domain.Provider
+import org.depromeet.clog.server.domain.user.domain.User
+import org.depromeet.clog.server.infrastructure.common.BaseEntity
+
+@Table(name = "user")
+@Entity
+class UserEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false, unique = true)
+    val loginId: String,
+
+    val name: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val provider: Provider,
+
+    @Column(nullable = false)
+    var isDeleted: Boolean = false
+) : BaseEntity() {
+
+    fun toDomain(): User = User(
+        id = id,
+        loginId = loginId,
+        name = name,
+        provider = provider,
+        isDeleted = isDeleted
+    )
+
+    companion object{
+        fun fromDomain(user: User): UserEntity = UserEntity(
+            id = user.id,
+            loginId = user.loginId,
+            name = user.name,
+            provider = user.provider,
+            isDeleted = user.isDeleted
+        )
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/user/UserJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/user/UserJpaRepository.kt
@@ -1,10 +1,9 @@
 package org.depromeet.clog.server.infrastructure.user
 
 import org.depromeet.clog.server.domain.user.domain.Provider
-import org.depromeet.clog.server.domain.user.domain.User
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface UserJpaRepository : JpaRepository<User, Long> {
-    fun findByLoginIdAndProvider(loginId: String, provider: Provider): User?
-    fun findByLoginId(loginId: String): User?
+interface UserJpaRepository : JpaRepository<UserEntity, Long> {
+    fun findByLoginIdAndProvider(loginId: String, provider: Provider): UserEntity?
+    fun findByLoginId(loginId: String): UserEntity?
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/user/UserRepositoryAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/user/UserRepositoryAdapter.kt
@@ -11,11 +11,11 @@ class UserRepositoryAdapter(
 ) : UserRepository {
 
     override fun findByLoginIdAndProvider(loginId: String, provider: Provider): User? =
-        userJpaRepository.findByLoginIdAndProvider(loginId, provider)
+        userJpaRepository.findByLoginIdAndProvider(loginId, provider)?.toDomain()
 
     override fun findByLoginId(loginId: String): User? =
-        userJpaRepository.findByLoginId(loginId)
+        userJpaRepository.findByLoginId(loginId)?.toDomain()
 
     override fun save(user: User): User =
-        userJpaRepository.save(user)
+        userJpaRepository.save(UserEntity.fromDomain(user)).toDomain()
 }


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- `BaseEntity`를 추가합니다.
  - `spring-boot-starter-data-jpa` dependency를 참조해야 하므로, `infrastructure` 모듈에 존재해야 합니다.
    - but, Jpa Entity가 `domain` 모듈에 있어 상속이 불가능합니다.
  - 따라서, 자연스럽게 Jpa Entity를 `infrastructure` 모듈로 옮기고, `domain` 계층에선 pojo를 사용하게 됩니다.
    - 멀티 모듈의 순기능! (순기능 맞겠죠?)

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- resolved #44 
