### PR TITLE
refactor : 프론트 요청으로 카카오 로그인을 idToken 전달받는 방식으로 수정

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/auth/controller/AuthController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/auth/controller/AuthController.kt
@@ -21,7 +21,7 @@ class AuthController(
 ) {
     @PostMapping("/kakao")
     fun kakaoLogin(@RequestBody request: KakaoLoginRequest): ApiResponse<AuthResponseDto> {
-        val authResponse = authService.kakaoLoginWithCode(request.code, request.codeVerifier)
+        val authResponse = authService.kakaoLoginWithIdToken(request.idToken)
         return ApiResponse.success(authResponse)
     }
 

--- a/clog-api/src/main/resources/application.yml
+++ b/clog-api/src/main/resources/application.yml
@@ -6,12 +6,9 @@ spring:
     oauth2:
       client:
         registration:
-          kakao:
-            client-name: KAKAO
-            client-id: ${KAKAO_CLIENT_ID}
           apple:
             client-name: APPLE
-            client-id: ${APPLE_CLIENT_ID}
+            client-id: ${APPLE_CLIENT_ID:com.supershy.climbinglog.dev}
             redirect-uri: "https://dev-api.climb-log.my/login/oauth2/code/apple"
             authorization-grant-type: authorization_code
             scope:
@@ -32,15 +29,17 @@ decorator:
       enable-logging: true
 
 jwt:
-  secret: ${JWT_SECRET}
+  secret: ${JWT_SECRET:your-secret-key}
   access-token-expiration-millis: 3600000
   refresh-token-expiration-millis: 604800000
 
 apple:
-  team-id: ${APPLE_TEAM_ID}
-  client-id: ${APPLE_CLIENT_ID}
-  key-id: ${APPLE_KEY_ID}
-  private-key: ${APPLE_PRIVATE_KEY}
+  team-id: ${APPLE_TEAM_ID:SUMATJC294}
+  client-id: ${APPLE_CLIENT_ID:com.supershy.climbinglog.dev}
+  key-id: ${APPLE_KEY_ID:2LCD3NVM7C}
+  private-key: ${APPLE_PRIVATE_KEY:-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgHNrrMRdZ8tqnHJ52\ncbwg/geX1Wj9NY96+wGaBv4bY++gCgYIKoZIzj0DAQehRANCAAT/XB7o6MlUvJNb\nlwVwoljgcPSlSXnN6TbWk3s+f9WBUp4SNDIKBcYmVE3uHgykvMN0ICLYLF5Zntzf\n7ojx67sL\n-----END PRIVATE KEY-----}
+kakao :
+  client-id: ${KAKAO_CLIENT_ID:bcd91f3c57fea5dcd79cb36287f3b714}
 
 springdoc:
   swagger-ui:

--- a/clog-api/src/main/resources/application.yml
+++ b/clog-api/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
         registration:
           apple:
             client-name: APPLE
-            client-id: ${APPLE_CLIENT_ID:com.supershy.climbinglog.dev}
+            client-id: ${APPLE_CLIENT_ID}
             redirect-uri: "https://dev-api.climb-log.my/login/oauth2/code/apple"
             authorization-grant-type: authorization_code
             scope:
@@ -29,17 +29,17 @@ decorator:
       enable-logging: true
 
 jwt:
-  secret: ${JWT_SECRET:your-secret-key}
+  secret: ${JWT_SECRET}
   access-token-expiration-millis: 3600000
   refresh-token-expiration-millis: 604800000
 
 apple:
-  team-id: ${APPLE_TEAM_ID:SUMATJC294}
-  client-id: ${APPLE_CLIENT_ID:com.supershy.climbinglog.dev}
-  key-id: ${APPLE_KEY_ID:2LCD3NVM7C}
-  private-key: ${APPLE_PRIVATE_KEY:-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgHNrrMRdZ8tqnHJ52\ncbwg/geX1Wj9NY96+wGaBv4bY++gCgYIKoZIzj0DAQehRANCAAT/XB7o6MlUvJNb\nlwVwoljgcPSlSXnN6TbWk3s+f9WBUp4SNDIKBcYmVE3uHgykvMN0ICLYLF5Zntzf\n7ojx67sL\n-----END PRIVATE KEY-----}
+  team-id: ${APPLE_TEAM_ID}
+  client-id: ${APPLE_CLIENT_ID}
+  key-id: ${APPLE_KEY_ID}
+  private-key: ${APPLE_PRIVATE_KEY}
 kakao :
-  client-id: ${KAKAO_CLIENT_ID:bcd91f3c57fea5dcd79cb36287f3b714}
+  client-id: ${KAKAO_CLIENT_ID}
 
 springdoc:
   swagger-ui:

--- a/clog-api/src/main/resources/application.yml
+++ b/clog-api/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
         registration:
           apple:
             client-name: APPLE
-            client-id: ${APPLE_CLIENT_ID}
+            client-id: ${APPLE_CLIENT_ID:com.supershy.climbinglog.dev}
             redirect-uri: "https://dev-api.climb-log.my/login/oauth2/code/apple"
             authorization-grant-type: authorization_code
             scope:
@@ -29,17 +29,17 @@ decorator:
       enable-logging: true
 
 jwt:
-  secret: ${JWT_SECRET}
+  secret: ${JWT_SECRET:your-secret-key}
   access-token-expiration-millis: 3600000
   refresh-token-expiration-millis: 604800000
 
 apple:
-  team-id: ${APPLE_TEAM_ID}
-  client-id: ${APPLE_CLIENT_ID}
-  key-id: ${APPLE_KEY_ID}
-  private-key: ${APPLE_PRIVATE_KEY}
+  team-id: ${APPLE_TEAM_ID:SUMATJC294}
+  client-id: ${APPLE_CLIENT_ID:com.supershy.climbinglog.dev}
+  key-id: ${APPLE_KEY_ID:2LCD3NVM7C}
+  private-key: ${APPLE_PRIVATE_KEY:-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgHNrrMRdZ8tqnHJ52\ncbwg/geX1Wj9NY96+wGaBv4bY++gCgYIKoZIzj0DAQehRANCAAT/XB7o6MlUvJNb\nlwVwoljgcPSlSXnN6TbWk3s+f9WBUp4SNDIKBcYmVE3uHgykvMN0ICLYLF5Zntzf\n7ojx67sL\n-----END PRIVATE KEY-----}
 kakao :
-  client-id: ${KAKAO_CLIENT_ID}
+  client-id: ${KAKAO_CLIENT_ID:bcd91f3c57fea5dcd79cb36287f3b714}
 
 springdoc:
   swagger-ui:

--- a/clog-api/src/main/resources/application.yml
+++ b/clog-api/src/main/resources/application.yml
@@ -9,11 +9,6 @@ spring:
           kakao:
             client-name: KAKAO
             client-id: ${KAKAO_CLIENT_ID}
-            redirect-uri: "https://dev-api.climb-log.my/login/oauth2/code/kakao"
-            authorization-grant-type: authorization_code
-            scope:
-              - openid
-              - profile_nickname
           apple:
             client-name: APPLE
             client-id: ${APPLE_CLIENT_ID}
@@ -24,11 +19,7 @@ spring:
               - name
         provider:
           kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize
-            token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kapi.kakao.com/v2/user/me
             jwk-set-uri: https://kauth.kakao.com/.well-known/jwks.json
-            user-name-attribute: sub
           apple:
             authorization-uri: https://appleid.apple.com/auth/authorize
             token-uri: https://appleid.apple.com/auth/token

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/AuthService.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/AuthService.kt
@@ -1,203 +1,22 @@
 package org.depromeet.clog.server.domain.auth.application
 
-import com.auth0.jwk.JwkProviderBuilder
-import com.auth0.jwt.JWT
-import com.auth0.jwt.JWTVerifier
-import com.auth0.jwt.algorithms.Algorithm
-import io.jsonwebtoken.Jwts
-import io.jsonwebtoken.SignatureAlgorithm
-import org.depromeet.clog.server.domain.auth.application.dto.*
-import org.depromeet.clog.server.domain.auth.presentation.exception.AuthErrorCode
-import org.depromeet.clog.server.domain.auth.presentation.exception.AuthException
-import org.depromeet.clog.server.domain.user.domain.Provider
-import org.depromeet.clog.server.domain.user.domain.User
-import org.depromeet.clog.server.domain.user.infrastructure.UserRepository
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.core.ParameterizedTypeReference
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpMethod
-import org.springframework.http.MediaType
+import org.depromeet.clog.server.domain.auth.application.dto.AppleLoginRequest
+import org.depromeet.clog.server.domain.auth.application.dto.AuthResponseDto
+import org.depromeet.clog.server.domain.auth.application.dto.KakaoLoginRequest
+import org.depromeet.clog.server.domain.auth.application.strategy.AppleAuthProviderHandler
+import org.depromeet.clog.server.domain.auth.application.strategy.KakaoAuthProviderHandler
 import org.springframework.stereotype.Service
-import org.springframework.util.LinkedMultiValueMap
-import org.springframework.web.client.RestTemplate
-import java.net.URL
-import java.security.KeyFactory
-import java.security.interfaces.RSAPublicKey
-import java.security.spec.PKCS8EncodedKeySpec
-import java.util.*
-import java.util.concurrent.TimeUnit
 
 @Service
 class AuthService(
-    private val tokenService: TokenService,
-    private val userRepository: UserRepository,
-    private val restTemplate: RestTemplate
+    private val kakaoAuthProviderHandler: KakaoAuthProviderHandler,
+    private val appleAuthProviderHandler: AppleAuthProviderHandler
 ) {
-
-    @Value("\${spring.security.oauth2.client.registration.kakao.client-id}")
-    private lateinit var kakaoClientId: String
-
-    @Value("\${apple.team-id}")
-    private lateinit var appleTeamId: String
-
-    @Value("\${apple.client-id}")
-    private lateinit var appleClientId: String
-
-    @Value("\${apple.key-id}")
-    private lateinit var appleKeyId: String
-
-    @Value("\${apple.private-key}")
-    private lateinit var applePrivateKey: String
-
-    // ---------------- Kakao 로그인 ----------------
-
     fun kakaoLoginWithIdToken(idToken: String): AuthResponseDto {
-        val kakaoUser = validateAndParseKakaoIdToken(idToken)
-        val user = userRepository.findByLoginIdAndProvider(kakaoUser.id, Provider.KAKAO)
-            ?: registerNewKakaoUser(kakaoUser)
-
-        return tokenService.generateTokens(user)
+        return kakaoAuthProviderHandler.login(KakaoLoginRequest(idToken))
     }
-
-    private fun validateAndParseKakaoIdToken(idToken: String): KakaoUserInfo {
-        try {
-            val jwksUrl = URL("https://kauth.kakao.com/.well-known/jwks.json")
-            val jwkProvider = JwkProviderBuilder(jwksUrl)
-                .cached(10, 24, TimeUnit.HOURS)
-                .rateLimited(10, 1, TimeUnit.MINUTES)
-                .build()
-            val decodedJWT = JWT.decode(idToken)
-            val keyId = decodedJWT.keyId ?: throw AuthException(AuthErrorCode.ID_TOKEN_VALIDATION_FAILED)
-            val jwk = jwkProvider.get(keyId)
-            val publicKey = jwk.publicKey as RSAPublicKey
-            val algorithm = Algorithm.RSA256(publicKey, null)
-            val verifier: JWTVerifier = JWT.require(algorithm)
-                .withIssuer("https://kauth.kakao.com")
-                .withAudience(kakaoClientId)
-                .build()
-            val verifiedJWT = verifier.verify(idToken)
-            val subject = verifiedJWT.subject
-                ?: throw AuthException(AuthErrorCode.ID_TOKEN_VALIDATION_FAILED)
-            val nickname = verifiedJWT.getClaim("nickname").asString() ?: "kakaoUser"
-            return KakaoUserInfo(
-                id = subject,
-                kakaoAccount = KakaoAccount(
-                    profile = KakaoProfile(nickname = nickname)
-                )
-            )
-        } catch (e: Exception) {
-            throw AuthException(AuthErrorCode.ID_TOKEN_VALIDATION_FAILED, e)
-        }
-    }
-
-    private fun registerNewKakaoUser(kakaoUserInfo: KakaoUserInfo): User {
-        val newUser = User(
-            loginId = kakaoUserInfo.id,
-            name = kakaoUserInfo.nickname,
-            provider = Provider.KAKAO
-        )
-        return userRepository.save(newUser)
-    }
-
-    // ---------------- Apple 로그인 ----------------
 
     fun appleLoginWithCode(authorizationCode: String, codeVerifier: String): AuthResponseDto {
-        val tokenResponse = requestAppleAccessToken(authorizationCode, codeVerifier)
-        val idToken = tokenResponse["id_token"] as? String
-            ?: throw AuthException(AuthErrorCode.ID_TOKEN_MISSING)
-        val appleUser = validateAndParseAppleIdToken(idToken)
-
-        val user = userRepository.findByLoginIdAndProvider(appleUser.id, Provider.APPLE)
-            ?: registerNewAppleUser(appleUser)
-
-        return tokenService.generateTokens(user)
-    }
-
-    private fun requestAppleAccessToken(
-        authorizationCode: String,
-        codeVerifier: String
-    ): Map<String, Any> {
-        val headers = HttpHeaders().apply { contentType = MediaType.APPLICATION_FORM_URLENCODED }
-        val body = LinkedMultiValueMap<String, String>().apply {
-            add("grant_type", "authorization_code")
-            add("code", authorizationCode)
-            add("redirect_uri", "http://localhost:8080/login/oauth2/code/apple")
-            add("client_id", appleClientId)
-            add("client_secret", generateAppleClientSecret())
-            add("code_verifier", codeVerifier)
-        }
-        val requestEntity = HttpEntity(body, headers)
-        val responseEntity = restTemplate.exchange(
-            "https://appleid.apple.com/auth/token",
-            HttpMethod.POST,
-            requestEntity,
-            object : ParameterizedTypeReference<Map<String, Any>>() {}
-        )
-        return responseEntity.body ?: throw AuthException(AuthErrorCode.TOKEN_INVALID)
-    }
-
-    private fun validateAndParseAppleIdToken(idToken: String): AppleUserInfo {
-        try {
-            val jwksUrl = URL("https://appleid.apple.com/auth/keys")
-            val jwkProvider = JwkProviderBuilder(jwksUrl)
-                .cached(10, 24, TimeUnit.HOURS)
-                .rateLimited(10, 1, TimeUnit.MINUTES)
-                .build()
-            val decodedJWT = JWT.decode(idToken)
-            val keyId =
-                decodedJWT.keyId ?: throw AuthException(AuthErrorCode.ID_TOKEN_VALIDATION_FAILED)
-            val jwk = jwkProvider.get(keyId)
-            val publicKey = jwk.publicKey as RSAPublicKey
-            val algorithm = Algorithm.RSA256(publicKey, null)
-            val verifier: JWTVerifier = JWT.require(algorithm)
-                .withIssuer("https://appleid.apple.com")
-                .withAudience(appleClientId)
-                .build()
-            val verifiedJWT = verifier.verify(idToken)
-            val subject =
-                verifiedJWT.subject ?: throw AuthException(AuthErrorCode.ID_TOKEN_VALIDATION_FAILED)
-            val name = verifiedJWT.getClaim("name").asString() ?: "appleUser"
-            return AppleUserInfo(id = subject, name = name)
-        } catch (e: Exception) {
-            throw AuthException(AuthErrorCode.ID_TOKEN_VALIDATION_FAILED, e)
-        }
-    }
-
-    private fun registerNewAppleUser(appleUser: AppleUserInfo): User {
-        val newUser = User(
-            loginId = appleUser.id,
-            name = appleUser.name,
-            provider = Provider.APPLE
-        )
-        return userRepository.save(newUser)
-    }
-
-    // Apple 클라이언트 시크릿 생성
-    private fun generateAppleClientSecret(): String {
-        val nowMillis = System.currentTimeMillis()
-        val expMillis = nowMillis + 180L * 24 * 60 * 60 * 1000
-
-        val formattedKey = "-----BEGIN PRIVATE KEY-----\n" +
-            applePrivateKey.replace("\\\\n", "\n").trim() +
-            "\n-----END PRIVATE KEY-----"
-        val decodedKey = Base64.getDecoder().decode(
-            formattedKey
-                .replace("-----BEGIN PRIVATE KEY-----", "")
-                .replace("-----END PRIVATE KEY-----", "")
-                .replace("\\s".toRegex(), "")
-        )
-        val keyFactory = KeyFactory.getInstance("EC")
-        val keySpec = PKCS8EncodedKeySpec(decodedKey)
-        val privateKey = keyFactory.generatePrivate(keySpec)
-        return Jwts.builder()
-            .setHeaderParam("kid", appleKeyId)
-            .setIssuer(appleTeamId)
-            .setIssuedAt(Date(nowMillis))
-            .setExpiration(Date(expMillis))
-            .setAudience("https://appleid.apple.com")
-            .setSubject(appleClientId)
-            .signWith(privateKey, SignatureAlgorithm.ES256)
-            .compact()
+        return appleAuthProviderHandler.login(AppleLoginRequest(authorizationCode, codeVerifier))
     }
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/TokenService.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/TokenService.kt
@@ -32,12 +32,26 @@ class TokenService(
      */
     fun generateTokens(user: User): AuthResponseDto {
         try {
-            val accessToken = createToken(user.loginId, user.provider.toString(), accessTokenExpirationMillis)
-            val refreshToken = createToken(user.loginId, user.provider.toString(), refreshTokenExpirationMillis)
+            val accessToken =
+                createToken(user.loginId, user.provider.toString(), accessTokenExpirationMillis)
+            val refreshToken =
+                createToken(user.loginId, user.provider.toString(), refreshTokenExpirationMillis)
 
             val refreshTokenValue = refreshToken.removePrefix("Bearer ")
-            refreshTokenRepository.deleteByLoginIdAndProvider(user.loginId, user.provider)
-            refreshTokenRepository.save(RefreshToken(user.loginId, user.provider, refreshTokenValue))
+            val userId = user.id
+                ?: throw AuthException(
+                    AuthErrorCode.AUTHENTICATION_FAILED,
+                    RuntimeException("존재하지 않는 userId")
+                )
+            refreshTokenRepository.deleteByUserIdAndProvider(userId, user.provider)
+            refreshTokenRepository.save(
+                RefreshToken(
+                    userId,
+                    user.loginId,
+                    user.provider,
+                    refreshTokenValue
+                )
+            )
 
             return AuthResponseDto(
                 provider = user.provider.toString(),

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/TokenService.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/TokenService.kt
@@ -35,8 +35,9 @@ class TokenService(
             val accessToken = createToken(user.loginId, user.provider.toString(), accessTokenExpirationMillis)
             val refreshToken = createToken(user.loginId, user.provider.toString(), refreshTokenExpirationMillis)
 
+            val refreshTokenValue = refreshToken.removePrefix("Bearer ")
             refreshTokenRepository.deleteByLoginIdAndProvider(user.loginId, user.provider)
-            refreshTokenRepository.save(RefreshToken(user.loginId, user.provider, refreshToken))
+            refreshTokenRepository.save(RefreshToken(user.loginId, user.provider, refreshTokenValue))
 
             return AuthResponseDto(
                 provider = user.provider.toString(),

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/KakaoLoginRequest.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/KakaoLoginRequest.kt
@@ -1,6 +1,5 @@
 package org.depromeet.clog.server.domain.auth.application.dto
 
 data class KakaoLoginRequest(
-    val code: String,
-    val codeVerifier: String
+    val idToken: String
 )

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/AppleAuthProviderHandler.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/AppleAuthProviderHandler.kt
@@ -34,20 +34,12 @@ import java.util.concurrent.TimeUnit
 class AppleAuthProviderHandler(
     private val tokenService: TokenService,
     private val userRepository: UserRepository,
-    private val restTemplate: RestTemplate
+    private val restTemplate: RestTemplate,
+    @Value("\${apple.team-id}") private val appleTeamId: String,
+    @Value("\${apple.client-id}") private val appleClientId: String,
+    @Value("\${apple.key-id}") private val appleKeyId: String,
+    @Value("\${apple.private-key}") private val applePrivateKey: String
 ) : AuthProviderHandler<AppleLoginRequest> {
-
-    @Value("\${apple.team-id}")
-    private lateinit var appleTeamId: String
-
-    @Value("\${apple.client-id}")
-    private lateinit var appleClientId: String
-
-    @Value("\${apple.key-id}")
-    private lateinit var appleKeyId: String
-
-    @Value("\${apple.private-key}")
-    private lateinit var applePrivateKey: String
 
     override fun login(request: AppleLoginRequest): AuthResponseDto {
         val tokenResponse = requestAppleAccessToken(request.code, request.codeVerifier)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/AppleAuthProviderHandler.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/AppleAuthProviderHandler.kt
@@ -1,0 +1,147 @@
+package org.depromeet.clog.server.domain.auth.application.strategy
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.JWTVerifier
+import com.auth0.jwt.algorithms.Algorithm
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import org.depromeet.clog.server.domain.auth.application.TokenService
+import org.depromeet.clog.server.domain.auth.application.dto.AppleLoginRequest
+import org.depromeet.clog.server.domain.auth.application.dto.AppleUserInfo
+import org.depromeet.clog.server.domain.auth.application.dto.AuthResponseDto
+import org.depromeet.clog.server.domain.auth.presentation.exception.AuthErrorCode
+import org.depromeet.clog.server.domain.auth.presentation.exception.AuthException
+import org.depromeet.clog.server.domain.user.domain.Provider
+import org.depromeet.clog.server.domain.user.domain.User
+import org.depromeet.clog.server.domain.user.infrastructure.UserRepository
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestTemplate
+import java.net.URL
+import java.security.KeyFactory
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+@Service
+class AppleAuthProviderHandler(
+    private val tokenService: TokenService,
+    private val userRepository: UserRepository,
+    private val restTemplate: RestTemplate
+) : AuthProviderHandler<AppleLoginRequest> {
+
+    @Value("\${apple.team-id}")
+    private lateinit var appleTeamId: String
+
+    @Value("\${apple.client-id}")
+    private lateinit var appleClientId: String
+
+    @Value("\${apple.key-id}")
+    private lateinit var appleKeyId: String
+
+    @Value("\${apple.private-key}")
+    private lateinit var applePrivateKey: String
+
+    override fun login(request: AppleLoginRequest): AuthResponseDto {
+        val tokenResponse = requestAppleAccessToken(request.code, request.codeVerifier)
+        val idToken = tokenResponse["id_token"] as? String
+            ?: throw AuthException(AuthErrorCode.ID_TOKEN_MISSING)
+        val appleUser = validateAndParseAppleIdToken(idToken)
+        val user = userRepository.findByLoginIdAndProvider(appleUser.id, Provider.APPLE)
+            ?: registerNewAppleUser(appleUser)
+        return tokenService.generateTokens(user)
+    }
+
+    private fun requestAppleAccessToken(
+        authorizationCode: String,
+        codeVerifier: String
+    ): Map<String, Any> {
+        val headers = HttpHeaders().apply { contentType = MediaType.APPLICATION_FORM_URLENCODED }
+        val body = LinkedMultiValueMap<String, String>().apply {
+            add("grant_type", "authorization_code")
+            add("code", authorizationCode)
+            add("redirect_uri", "http://localhost:8080/login/oauth2/code/apple")
+            add("client_id", appleClientId)
+            add("client_secret", generateAppleClientSecret())
+            add("code_verifier", codeVerifier)
+        }
+        val requestEntity = HttpEntity(body, headers)
+        val responseEntity = restTemplate.exchange(
+            "https://appleid.apple.com/auth/token",
+            HttpMethod.POST,
+            requestEntity,
+            object : ParameterizedTypeReference<Map<String, Any>>() {}
+        )
+        return responseEntity.body ?: throw AuthException(AuthErrorCode.TOKEN_INVALID)
+    }
+
+    private fun validateAndParseAppleIdToken(idToken: String): AppleUserInfo {
+        try {
+            val jwksUrl = URL("https://appleid.apple.com/auth/keys")
+            val jwkProvider = com.auth0.jwk.JwkProviderBuilder(jwksUrl)
+                .cached(10, 24, TimeUnit.HOURS)
+                .rateLimited(10, 1, TimeUnit.MINUTES)
+                .build()
+            val decodedJWT = JWT.decode(idToken)
+            val keyId =
+                decodedJWT.keyId ?: throw AuthException(AuthErrorCode.ID_TOKEN_VALIDATION_FAILED)
+            val jwk = jwkProvider.get(keyId)
+            val publicKey = jwk.publicKey as RSAPublicKey
+            val algorithm = Algorithm.RSA256(publicKey, null)
+            val verifier: JWTVerifier = JWT.require(algorithm)
+                .withIssuer("https://appleid.apple.com")
+                .withAudience(appleClientId)
+                .build()
+            val verifiedJWT = verifier.verify(idToken)
+            val subject =
+                verifiedJWT.subject ?: throw AuthException(AuthErrorCode.ID_TOKEN_VALIDATION_FAILED)
+            val name = verifiedJWT.getClaim("name").asString() ?: "appleUser"
+            return AppleUserInfo(id = subject, name = name)
+        } catch (e: Exception) {
+            throw AuthException(AuthErrorCode.ID_TOKEN_VALIDATION_FAILED, e)
+        }
+    }
+
+    private fun registerNewAppleUser(appleUser: AppleUserInfo): User {
+        val newUser = User(
+            loginId = appleUser.id,
+            name = appleUser.name,
+            provider = Provider.APPLE
+        )
+        return userRepository.save(newUser)
+    }
+
+    private fun generateAppleClientSecret(): String {
+        val nowMillis = System.currentTimeMillis()
+        val expMillis = nowMillis + 180L * 24 * 60 * 60 * 1000
+
+        val formattedKey = "-----BEGIN PRIVATE KEY-----\n" +
+                applePrivateKey.replace("\\\\n", "\n").trim() +
+                "\n-----END PRIVATE KEY-----"
+        val decodedKey = Base64.getDecoder().decode(
+            formattedKey
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replace("\\s".toRegex(), "")
+        )
+        val keyFactory = KeyFactory.getInstance("EC")
+        val keySpec = PKCS8EncodedKeySpec(decodedKey)
+        val privateKey = keyFactory.generatePrivate(keySpec)
+        return Jwts.builder()
+            .setHeaderParam("kid", appleKeyId)
+            .setIssuer(appleTeamId)
+            .setIssuedAt(Date(nowMillis))
+            .setExpiration(Date(expMillis))
+            .setAudience("https://appleid.apple.com")
+            .setSubject(appleClientId)
+            .signWith(privateKey, SignatureAlgorithm.ES256)
+            .compact()
+    }
+}

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/AuthProviderHandler.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/AuthProviderHandler.kt
@@ -1,0 +1,7 @@
+package org.depromeet.clog.server.domain.auth.application.strategy
+
+import org.depromeet.clog.server.domain.auth.application.dto.AuthResponseDto
+
+interface AuthProviderHandler<T> {
+    fun login(request: T): AuthResponseDto
+}

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/KakaoAuthProviderHandler.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/KakaoAuthProviderHandler.kt
@@ -23,7 +23,7 @@ class KakaoAuthProviderHandler(
     private val userRepository: UserRepository
 ) : AuthProviderHandler<KakaoLoginRequest> {
 
-    @Value("\${spring.security.oauth2.client.registration.kakao.client-id}")
+    @Value("\${kakao.client-id}")
     private lateinit var kakaoClientId: String
 
     override fun login(request: KakaoLoginRequest): AuthResponseDto {

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/KakaoAuthProviderHandler.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/KakaoAuthProviderHandler.kt
@@ -1,0 +1,76 @@
+package org.depromeet.clog.server.domain.auth.application.strategy
+
+import com.auth0.jwk.JwkProviderBuilder
+import com.auth0.jwt.JWT
+import com.auth0.jwt.JWTVerifier
+import com.auth0.jwt.algorithms.Algorithm
+import org.depromeet.clog.server.domain.auth.application.TokenService
+import org.depromeet.clog.server.domain.auth.application.dto.*
+import org.depromeet.clog.server.domain.auth.presentation.exception.AuthErrorCode
+import org.depromeet.clog.server.domain.auth.presentation.exception.AuthException
+import org.depromeet.clog.server.domain.user.domain.Provider
+import org.depromeet.clog.server.domain.user.domain.User
+import org.depromeet.clog.server.domain.user.infrastructure.UserRepository
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.net.URL
+import java.security.interfaces.RSAPublicKey
+import java.util.concurrent.TimeUnit
+
+@Service
+class KakaoAuthProviderHandler(
+    private val tokenService: TokenService,
+    private val userRepository: UserRepository
+) : AuthProviderHandler<KakaoLoginRequest> {
+
+    @Value("\${spring.security.oauth2.client.registration.kakao.client-id}")
+    private lateinit var kakaoClientId: String
+
+    override fun login(request: KakaoLoginRequest): AuthResponseDto {
+        val kakaoUser = validateAndParseKakaoIdToken(request.idToken)
+        val user = userRepository.findByLoginIdAndProvider(kakaoUser.id, Provider.KAKAO)
+            ?: registerNewKakaoUser(kakaoUser)
+        return tokenService.generateTokens(user)
+    }
+
+    private fun validateAndParseKakaoIdToken(idToken: String): KakaoUserInfo {
+        try {
+            val jwksUrl = URL("https://kauth.kakao.com/.well-known/jwks.json")
+            val jwkProvider = JwkProviderBuilder(jwksUrl)
+                .cached(10, 24, TimeUnit.HOURS)
+                .rateLimited(10, 1, TimeUnit.MINUTES)
+                .build()
+            val decodedJWT = JWT.decode(idToken)
+            val keyId =
+                decodedJWT.keyId ?: throw AuthException(AuthErrorCode.ID_TOKEN_VALIDATION_FAILED)
+            val jwk = jwkProvider.get(keyId)
+            val publicKey = jwk.publicKey as RSAPublicKey
+            val algorithm: Algorithm = Algorithm.RSA256(publicKey, null)
+            val verifier: JWTVerifier = JWT.require(algorithm)
+                .withIssuer("https://kauth.kakao.com")
+                .withAudience(kakaoClientId)
+                .build()
+            val verifiedJWT = verifier.verify(idToken)
+            val subject =
+                verifiedJWT.subject ?: throw AuthException(AuthErrorCode.ID_TOKEN_VALIDATION_FAILED)
+            val nickname = verifiedJWT.getClaim("nickname").asString() ?: "kakaoUser"
+            return KakaoUserInfo(
+                id = subject,
+                kakaoAccount = KakaoAccount(
+                    profile = KakaoProfile(nickname = nickname)
+                )
+            )
+        } catch (e: Exception) {
+            throw AuthException(AuthErrorCode.ID_TOKEN_VALIDATION_FAILED, e)
+        }
+    }
+
+    private fun registerNewKakaoUser(kakaoUserInfo: KakaoUserInfo): User {
+        val newUser = User(
+            loginId = kakaoUserInfo.id,
+            name = kakaoUserInfo.nickname,
+            provider = Provider.KAKAO
+        )
+        return userRepository.save(newUser)
+    }
+}

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/KakaoAuthProviderHandler.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/KakaoAuthProviderHandler.kt
@@ -20,11 +20,9 @@ import java.util.concurrent.TimeUnit
 @Service
 class KakaoAuthProviderHandler(
     private val tokenService: TokenService,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    @Value("\${kakao.client-id}") private val kakaoClientId: String
 ) : AuthProviderHandler<KakaoLoginRequest> {
-
-    @Value("\${kakao.client-id}")
-    private lateinit var kakaoClientId: String
 
     override fun login(request: KakaoLoginRequest): AuthResponseDto {
         val kakaoUser = validateAndParseKakaoIdToken(request.idToken)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/domain/RefreshToken.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/domain/RefreshToken.kt
@@ -1,18 +1,9 @@
 package org.depromeet.clog.server.domain.auth.domain
 
-import jakarta.persistence.Entity
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
-import jakarta.persistence.Id
 import org.depromeet.clog.server.domain.user.domain.Provider
 
-@Entity
-class RefreshToken(
-    @Id
+data class RefreshToken(
     val loginId: String,
-
-    @Enumerated(EnumType.STRING)
     val provider: Provider,
-
     var token: String
 )

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/domain/RefreshToken.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/domain/RefreshToken.kt
@@ -3,6 +3,7 @@ package org.depromeet.clog.server.domain.auth.domain
 import org.depromeet.clog.server.domain.user.domain.Provider
 
 data class RefreshToken(
+    val userId: Long,
     val loginId: String,
     val provider: Provider,
     var token: String

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/infrastructure/RefreshTokenRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/infrastructure/RefreshTokenRepository.kt
@@ -6,5 +6,5 @@ import org.depromeet.clog.server.domain.user.domain.Provider
 interface RefreshTokenRepository {
     fun save(token: RefreshToken): RefreshToken
     fun findById(id: String): RefreshToken?
-    fun deleteByLoginIdAndProvider(loginId: String, provider: Provider)
+    fun deleteByUserIdAndProvider(userId: Long, provider: Provider)
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenEntity.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenEntity.kt
@@ -1,13 +1,11 @@
 package org.depromeet.clog.server.infrastructure.auth
 
-import jakarta.persistence.Entity
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
-import jakarta.persistence.Id
+import jakarta.persistence.*
 import org.depromeet.clog.server.domain.auth.domain.RefreshToken
 import org.depromeet.clog.server.domain.user.domain.Provider
 
 @Entity
+@Table(name = "refresh_token")
 class RefreshTokenEntity(
     @Id
     val userId: Long,

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenEntity.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenEntity.kt
@@ -1,0 +1,34 @@
+package org.depromeet.clog.server.infrastructure.auth
+
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import org.depromeet.clog.server.domain.auth.domain.RefreshToken
+import org.depromeet.clog.server.domain.user.domain.Provider
+
+@Entity
+class RefreshTokenEntity(
+    @Id
+    val loginId: String,
+
+    @Enumerated(EnumType.STRING)
+    val provider: Provider,
+
+    var token: String
+) {
+    fun toDomain(): RefreshToken = RefreshToken(
+        loginId = loginId,
+        provider = provider,
+        token = token
+    )
+
+    companion object {
+        fun fromDomain(refreshToken: RefreshToken): RefreshTokenEntity =
+            RefreshTokenEntity(
+                loginId = refreshToken.loginId,
+                provider = refreshToken.provider,
+                token = refreshToken.token
+            )
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenEntity.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenEntity.kt
@@ -10,6 +10,8 @@ import org.depromeet.clog.server.domain.user.domain.Provider
 @Entity
 class RefreshTokenEntity(
     @Id
+    val userId: Long,
+
     val loginId: String,
 
     @Enumerated(EnumType.STRING)
@@ -18,6 +20,7 @@ class RefreshTokenEntity(
     var token: String
 ) {
     fun toDomain(): RefreshToken = RefreshToken(
+        userId = userId,
         loginId = loginId,
         provider = provider,
         token = token
@@ -26,6 +29,7 @@ class RefreshTokenEntity(
     companion object {
         fun fromDomain(refreshToken: RefreshToken): RefreshTokenEntity =
             RefreshTokenEntity(
+                userId = refreshToken.userId,
                 loginId = refreshToken.loginId,
                 provider = refreshToken.provider,
                 token = refreshToken.token

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenJpaRepository.kt
@@ -1,9 +1,8 @@
 package org.depromeet.clog.server.infrastructure.auth
 
-import org.depromeet.clog.server.domain.auth.domain.RefreshToken
 import org.depromeet.clog.server.domain.user.domain.Provider
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface RefreshTokenJpaRepository : JpaRepository<RefreshToken, String>{
+interface RefreshTokenJpaRepository : JpaRepository<RefreshTokenEntity, String> {
     fun deleteByLoginIdAndProvider(loginId: String, provider: Provider)
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenJpaRepository.kt
@@ -4,5 +4,5 @@ import org.depromeet.clog.server.domain.user.domain.Provider
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface RefreshTokenJpaRepository : JpaRepository<RefreshTokenEntity, String> {
-    fun deleteByLoginIdAndProvider(loginId: String, provider: Provider)
+    fun deleteByUserIdAndProvider(userId: Long, provider: Provider)
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenRepositoryAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenRepositoryAdapter.kt
@@ -19,6 +19,6 @@ class RefreshTokenRepositoryAdapter(
     override fun findById(id: String): RefreshToken? =
         refreshTokenJpaRepository.findByIdOrNull(id)?.toDomain()
 
-    override fun deleteByLoginIdAndProvider(loginId: String, provider: Provider) =
-        refreshTokenJpaRepository.deleteByLoginIdAndProvider(loginId, provider)
+    override fun deleteByUserIdAndProvider(userId: Long, provider: Provider) =
+        refreshTokenJpaRepository.deleteByUserIdAndProvider(userId, provider)
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenRepositoryAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenRepositoryAdapter.kt
@@ -11,11 +11,13 @@ class RefreshTokenRepositoryAdapter(
     private val refreshTokenJpaRepository: RefreshTokenJpaRepository
 ) : RefreshTokenRepository {
 
-    override fun save(token: RefreshToken): RefreshToken =
-        refreshTokenJpaRepository.save(token)
+    override fun save(token: RefreshToken): RefreshToken {
+        val entity = RefreshTokenEntity.fromDomain(token)
+        return refreshTokenJpaRepository.save(entity).toDomain()
+    }
 
     override fun findById(id: String): RefreshToken? =
-        refreshTokenJpaRepository.findByIdOrNull(id)
+        refreshTokenJpaRepository.findByIdOrNull(id)?.toDomain()
 
     override fun deleteByLoginIdAndProvider(loginId: String, provider: Provider) =
         refreshTokenJpaRepository.deleteByLoginIdAndProvider(loginId, provider)


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
- 프론트 요청사항으로 카카오 로그인만 authorization code를 넘겨받는 방식에서 idToken을 직접 넘겨받는 방식으로 수정했습니다.
- IdToken을 바로 넘겨받는 방식은 보안상 매우 안좋으므로 이 방식은 추후에 프론트와 합의하겠습니다.
- refreshToken 저장시에 "Bareer"도 같이 저장되는 부분 수정하였습니다.
- refreshToken엔티티를 infra모듈로 이동하였습니다.
- Provider별 인증 로직 분리 및 전략 패턴 적용
- refreshToken의 loginId의 중복 가능성을 고려해 userId를 사용하도록 추가
