### PR TITLE
[SPS-79] Crag 스케줄링 추가

### DIFF
--- a/clog-infrastructure/build.gradle.kts
+++ b/clog-infrastructure/build.gradle.kts
@@ -4,6 +4,7 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.10.0")
+    implementation("org.apache.httpcomponents.client5:httpclient5:5.4.2")
 
     implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.5.4")
     implementation("com.linecorp.kotlin-jdsl:jpql-render:3.5.4")

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/configuration/KakaoMapRestClientConfig.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/configuration/KakaoMapRestClientConfig.kt
@@ -1,0 +1,67 @@
+package org.depromeet.clog.server.infrastructure.configuration
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager
+import org.depromeet.clog.server.infrastructure.configuration.properties.KakaoMapProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.MediaType
+import org.springframework.http.client.ClientHttpRequestFactory
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+import org.springframework.web.client.RestClient
+
+@Configuration
+@EnableConfigurationProperties(KakaoMapProperties::class)
+class KakaoMapRestClientConfig(
+    private val properties: KakaoMapProperties
+) {
+
+    private val logger = KotlinLogging.logger { KakaoMapRestClientConfig::class.java.name }
+
+    companion object {
+        const val MAX_CONNECTION_TOTAL = 3
+        const val MAX_PER_ROUTE = 5
+    }
+
+    @Bean
+    fun kakaoMapRestClient(): RestClient {
+        return RestClient.builder()
+            .requestFactory(httpRequestFactory())
+            .baseUrl(properties.localSearchBaseUrl)
+            .defaultHeaders { headers ->
+                headers.set(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK ${properties.restApiKey}")
+            }
+            .defaultStatusHandler(HttpStatusCode::is5xxServerError) { request, response ->
+                logger.error {
+                    "Kakao Map API request failed. " +
+                        "Status: ${response.statusCode}, " +
+                        "URL: ${request.uri}, " +
+                        "Method: ${request.method}"
+                }
+            }
+            .build()
+    }
+
+    @Bean
+    fun httpRequestFactory(): ClientHttpRequestFactory {
+        val httpClient = HttpClients.custom()
+            .setConnectionManager(pollConnectionManager())
+            .build()
+
+        return HttpComponentsClientHttpRequestFactory(httpClient)
+    }
+
+    @Bean
+    fun pollConnectionManager(): PoolingHttpClientConnectionManager {
+        val manager = PoolingHttpClientConnectionManager()
+        manager.maxTotal = MAX_CONNECTION_TOTAL
+        manager.defaultMaxPerRoute = MAX_PER_ROUTE
+
+        return manager
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/configuration/properties/KakaoMapProperties.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/configuration/properties/KakaoMapProperties.kt
@@ -1,0 +1,9 @@
+package org.depromeet.clog.server.infrastructure.configuration.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "kakao.map")
+data class KakaoMapProperties(
+    val restApiKey: String,
+    val localSearchBaseUrl: String
+)

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/CragJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/CragJpaRepository.kt
@@ -2,4 +2,6 @@ package org.depromeet.clog.server.infrastructure.crag
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CragJpaRepository : JpaRepository<CragEntity, Long>
+interface CragJpaRepository : JpaRepository<CragEntity, Long> {
+    fun existsByKakaoPlaceId(kakaoPlaceId: Long): Boolean
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/scheduling/CragSchedulingTask.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/scheduling/CragSchedulingTask.kt
@@ -1,0 +1,115 @@
+package org.depromeet.clog.server.infrastructure.crag.scheduling
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.depromeet.clog.server.domain.crag.domain.Coordinate
+import org.depromeet.clog.server.domain.crag.domain.Crag
+import org.depromeet.clog.server.infrastructure.crag.CragEntity
+import org.depromeet.clog.server.infrastructure.crag.CragJpaRepository
+import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+import org.springframework.web.client.RestClient
+
+@Component
+class CragSchedulingTask(
+    private val cragJpaRepository: CragJpaRepository,
+    private val kakaoMapRestClient: RestClient
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    data class KakaoSearchResponse(
+        val documents: List<KakaoSearchDocument>,
+        val meta: KakaoSearchMeta
+    )
+
+    data class KakaoSearchDocument(
+        val id: Long,
+        @JsonProperty("place_name") val placeName: String,
+        @JsonProperty("road_address_name") val roadAddressName: String,
+        val x: Double,
+        val y: Double
+    )
+
+    data class KakaoSearchMeta(
+        @JsonProperty("is_end") val isEnd: Boolean
+    )
+
+    companion object {
+        const val MAX_PAGE_SIZE = 3
+        const val LOCATION_BASE_QUERY = "클라이밍"
+        val SEOUL_DISTRICTS = listOf(
+            "강남구", "강동구", "강북구", "강서구", "관악구", "광진구", "구로구", "금천구",
+            "노원구", "도봉구", "동대문구", "동작구", "마포구", "서대문구", "서초구", "성동구",
+            "성북구", "송파구", "양천구", "영등포구", "용산구", "은평구", "종로구", "중구", "중랑구"
+        )
+    }
+
+    // @Scheduled
+    fun saveCragSchedule() {
+        SEOUL_DISTRICTS.forEach { district ->
+            searchAndSaveCragInDistrict(district)
+        }
+    }
+
+    private fun searchAndSaveCragInDistrict(district: String) {
+        var page = 1
+        var isEnd = false
+        val query = "$LOCATION_BASE_QUERY $district"
+
+        while (!isEnd && page <= MAX_PAGE_SIZE) {
+            searchKakaoLocationResult(query, page)?.let { response ->
+                saveAndUpdateCrag(response)
+            } ?: run {
+                logger.info { "No response received for $district, page $page" }
+                isEnd = true
+            }
+
+            page++
+        }
+    }
+
+    private fun createParams(
+        query: String,
+        page: Int
+    ): MultiValueMap<String, String> {
+        val params: MultiValueMap<String, String> = LinkedMultiValueMap<String, String>().apply {
+            add("query", query)
+            add("page", page.toString())
+        }
+
+        return params
+    }
+
+    private fun searchKakaoLocationResult(
+        query: String,
+        page: Int
+    ): KakaoSearchResponse? {
+        return kakaoMapRestClient.get()
+            .uri { it.queryParams(createParams(query, page)).build() }
+            .retrieve()
+            .body(KakaoSearchResponse::class.java)
+    }
+
+    private fun saveAndUpdateCrag(response: KakaoSearchResponse) {
+        val newCrags = response.documents
+            .filterNot { cragJpaRepository.existsByKakaoPlaceId(it.id) }
+            .map { doc ->
+                Crag(
+                    name = doc.placeName,
+                    roadAddress = doc.roadAddressName,
+                    coordinate = Coordinate(
+                        longitude = doc.x,
+                        latitude = doc.y
+                    ),
+                    kakaoPlaceId = doc.id
+                )
+            }
+
+        if (newCrags.isNotEmpty()) {
+            cragJpaRepository.saveAll(newCrags.map { CragEntity.fromDomain(it) })
+                .map { it.toDomain() }
+        }
+    }
+}

--- a/clog-infrastructure/src/main/resources/application-local.yml
+++ b/clog-infrastructure/src/main/resources/application-local.yml
@@ -9,3 +9,8 @@ decorator:
   datasource:
     p6spy:
       enable-logging: true
+
+kakao:
+  map:
+    rest-api-key: ${KAKAO_MAP_REST_API_KEY}
+    local-search-base-url: ${KAKAO_MAP_LOCAL_SEARCH_BASE_URL}


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

1. RestClient vs WebClient
- RestClient를 선택한 이유는 카카오맵 API를 통해 암장을 조회할 때 대량의 데이터가 반환되지 않았기 때문입니다. 이러한 상황에서는 WebClient가 제공하는 비동기 및 논블로킹 기능의 이점이 크지 않다고 판단했고, restclient로도 충분한 성능을 제공할 것이라 생각합니다.

2. KakaoMap API 스케줄링 추가
<br>

** 리뷰 포인트 **
- 스케줄링 시간 설정
- 현재 작업의 구현 위치 (infrastructure vs domain - application)


## 관련링크 (JIRA, Github, etc)
<!--
- 
-->
- [SPS-79](https://depromeet-16-5.atlassian.net/browse/SPS-79?atlOrigin=eyJpIjoiM2QyYmFiYTM5YjBmNDljZjliYzA1N2RhMTQxNjJhMGEiLCJwIjoiaiJ9)


[SPS-79]: https://depromeet-16-5.atlassian.net/browse/SPS-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ