### PR TITLE
feat : 액세스토큰 재발급 api 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ subprojects {
         implementation("org.springframework.boot:spring-boot-starter-web")
         implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
         implementation("io.github.oshai:kotlin-logging-jvm:7.0.4")
+        implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
 
         testImplementation(kotlin("test"))
         testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/auth/presentation/AuthController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/auth/presentation/AuthController.kt
@@ -3,10 +3,12 @@ package org.depromeet.clog.server.api.auth.presentation
 import org.depromeet.clog.server.api.configuration.ApiConstants.API_BASE_PATH_V1
 import org.depromeet.clog.server.api.configuration.annotation.ApiErrorCodes
 import org.depromeet.clog.server.domain.auth.application.AuthService
-import org.depromeet.clog.server.domain.auth.application.dto.AppleLoginRequest
-import org.depromeet.clog.server.domain.auth.application.dto.AuthResponseDto
-import org.depromeet.clog.server.domain.auth.application.dto.KakaoLoginRequest
-import org.depromeet.clog.server.domain.auth.application.dto.LocalLoginRequest
+import org.depromeet.clog.server.domain.auth.application.TokenService
+import org.depromeet.clog.server.domain.auth.application.dto.request.AppleLoginRequest
+import org.depromeet.clog.server.domain.auth.application.dto.request.KakaoLoginRequest
+import org.depromeet.clog.server.domain.auth.application.dto.request.LocalLoginRequest
+import org.depromeet.clog.server.domain.auth.application.dto.request.RefreshTokenRequest
+import org.depromeet.clog.server.domain.auth.application.dto.response.AuthResponseDto
 import org.depromeet.clog.server.domain.common.ClogApiResponse
 import org.depromeet.clog.server.domain.common.ErrorCode
 import org.springframework.context.annotation.Profile
@@ -18,7 +20,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("$API_BASE_PATH_V1/auth")
 class AuthController(
-    private val authService: AuthService
+    private val authService: AuthService,
+    private val tokenService: TokenService
 ) {
     @PostMapping("/kakao")
     @ApiErrorCodes([ErrorCode.TOKEN_EXPIRED])
@@ -31,6 +34,12 @@ class AuthController(
     fun appleLogin(@RequestBody request: AppleLoginRequest): ClogApiResponse<AuthResponseDto> {
         val authResponse = authService.appleLoginWithCode(request.code, request.codeVerifier)
         return ClogApiResponse.from(authResponse)
+    }
+
+    @PostMapping("/reissue/access-token")
+    fun refreshToken(@RequestBody request: RefreshTokenRequest): ClogApiResponse<AuthResponseDto> {
+        val response = tokenService.refreshAccessToken(request.refreshToken)
+        return ClogApiResponse.from(response)
     }
 
     @Profile("dev", "local")

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/AuthService.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/AuthService.kt
@@ -1,10 +1,10 @@
 package org.depromeet.clog.server.domain.auth.application
 
 import jakarta.transaction.Transactional
-import org.depromeet.clog.server.domain.auth.application.dto.AppleLoginRequest
-import org.depromeet.clog.server.domain.auth.application.dto.AuthResponseDto
-import org.depromeet.clog.server.domain.auth.application.dto.KakaoLoginRequest
-import org.depromeet.clog.server.domain.auth.application.dto.LocalLoginRequest
+import org.depromeet.clog.server.domain.auth.application.dto.request.AppleLoginRequest
+import org.depromeet.clog.server.domain.auth.application.dto.request.KakaoLoginRequest
+import org.depromeet.clog.server.domain.auth.application.dto.request.LocalLoginRequest
+import org.depromeet.clog.server.domain.auth.application.dto.response.AuthResponseDto
 import org.depromeet.clog.server.domain.auth.application.strategy.AppleAuthProviderHandler
 import org.depromeet.clog.server.domain.auth.application.strategy.KakaoAuthProviderHandler
 import org.depromeet.clog.server.domain.auth.application.strategy.LocalAuthProviderHandler

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/KakaoLoginRequest.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/KakaoLoginRequest.kt
@@ -1,5 +1,0 @@
-package org.depromeet.clog.server.domain.auth.application.dto
-
-data class KakaoLoginRequest(
-    val idToken: String
-)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/LocalLoginRequest.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/LocalLoginRequest.kt
@@ -1,5 +1,0 @@
-package org.depromeet.clog.server.domain.auth.application.dto
-
-data class LocalLoginRequest(
-    val loginId: String
-)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/request/AppleLoginRequest.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/request/AppleLoginRequest.kt
@@ -1,4 +1,4 @@
-package org.depromeet.clog.server.domain.auth.application.dto
+package org.depromeet.clog.server.domain.auth.application.dto.request
 
 data class AppleLoginRequest(
     val code: String,

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/request/KakaoLoginRequest.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/request/KakaoLoginRequest.kt
@@ -1,0 +1,5 @@
+package org.depromeet.clog.server.domain.auth.application.dto.request
+
+data class KakaoLoginRequest(
+    val idToken: String
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/request/LocalLoginRequest.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/request/LocalLoginRequest.kt
@@ -1,0 +1,5 @@
+package org.depromeet.clog.server.domain.auth.application.dto.request
+
+data class LocalLoginRequest(
+    val loginId: String
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/request/RefreshTokenRequest.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/request/RefreshTokenRequest.kt
@@ -1,0 +1,5 @@
+package org.depromeet.clog.server.domain.auth.application.dto.request
+
+data class RefreshTokenRequest(
+    val refreshToken: String
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/response/AuthResponseDto.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/dto/response/AuthResponseDto.kt
@@ -1,4 +1,4 @@
-package org.depromeet.clog.server.domain.auth.application.dto
+package org.depromeet.clog.server.domain.auth.application.dto.response
 
 data class AuthResponseDto(
     val provider: String,

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/AppleAuthProviderHandler.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/AppleAuthProviderHandler.kt
@@ -7,9 +7,9 @@ import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import jakarta.transaction.Transactional
 import org.depromeet.clog.server.domain.auth.application.TokenService
-import org.depromeet.clog.server.domain.auth.application.dto.AppleLoginRequest
 import org.depromeet.clog.server.domain.auth.application.dto.AppleUserInfo
-import org.depromeet.clog.server.domain.auth.application.dto.AuthResponseDto
+import org.depromeet.clog.server.domain.auth.application.dto.request.AppleLoginRequest
+import org.depromeet.clog.server.domain.auth.application.dto.response.AuthResponseDto
 import org.depromeet.clog.server.domain.auth.presentation.exception.AuthException
 import org.depromeet.clog.server.domain.common.ErrorCode
 import org.depromeet.clog.server.domain.user.domain.Provider
@@ -126,9 +126,8 @@ class AppleAuthProviderHandler(
         val nowMillis = System.currentTimeMillis()
         val expMillis = nowMillis + 180L * 24 * 60 * 60 * 1000
 
-        val formattedKey = "-----BEGIN PRIVATE KEY-----\n" +
-            applePrivateKey.replace("\\\\n", "\n").trim() +
-            "\n-----END PRIVATE KEY-----"
+        val formattedKey = "-----BEGIN PRIVATE KEY-----\n" + applePrivateKey.replace("\\\\n", "\n")
+            .trim() + "\n-----END PRIVATE KEY-----"
         val decodedKey = Base64.getDecoder().decode(
             formattedKey
                 .replace("-----BEGIN PRIVATE KEY-----", "")

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/AuthProviderHandler.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/AuthProviderHandler.kt
@@ -1,6 +1,6 @@
 package org.depromeet.clog.server.domain.auth.application.strategy
 
-import org.depromeet.clog.server.domain.auth.application.dto.AuthResponseDto
+import org.depromeet.clog.server.domain.auth.application.dto.response.AuthResponseDto
 
 interface AuthProviderHandler<T> {
     fun login(request: T): AuthResponseDto

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/KakaoAuthProviderHandler.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/KakaoAuthProviderHandler.kt
@@ -6,7 +6,11 @@ import com.auth0.jwt.JWTVerifier
 import com.auth0.jwt.algorithms.Algorithm
 import jakarta.transaction.Transactional
 import org.depromeet.clog.server.domain.auth.application.TokenService
-import org.depromeet.clog.server.domain.auth.application.dto.*
+import org.depromeet.clog.server.domain.auth.application.dto.KakaoAccount
+import org.depromeet.clog.server.domain.auth.application.dto.KakaoProfile
+import org.depromeet.clog.server.domain.auth.application.dto.KakaoUserInfo
+import org.depromeet.clog.server.domain.auth.application.dto.request.KakaoLoginRequest
+import org.depromeet.clog.server.domain.auth.application.dto.response.AuthResponseDto
 import org.depromeet.clog.server.domain.auth.presentation.exception.AuthException
 import org.depromeet.clog.server.domain.common.ErrorCode
 import org.depromeet.clog.server.domain.user.domain.Provider

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/LocalAuthProviderHandler.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/auth/application/strategy/LocalAuthProviderHandler.kt
@@ -2,8 +2,8 @@ package org.depromeet.clog.server.domain.auth.application.strategy
 
 import jakarta.transaction.Transactional
 import org.depromeet.clog.server.domain.auth.application.TokenService
-import org.depromeet.clog.server.domain.auth.application.dto.AuthResponseDto
-import org.depromeet.clog.server.domain.auth.application.dto.LocalLoginRequest
+import org.depromeet.clog.server.domain.auth.application.dto.request.LocalLoginRequest
+import org.depromeet.clog.server.domain.auth.application.dto.response.AuthResponseDto
 import org.depromeet.clog.server.domain.user.domain.Provider
 import org.depromeet.clog.server.domain.user.domain.User
 import org.depromeet.clog.server.domain.user.domain.UserRepository

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/user/application/UserService.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/user/application/UserService.kt
@@ -8,12 +8,11 @@ import org.depromeet.clog.server.domain.user.presentation.exception.UserExceptio
 import org.springframework.stereotype.Service
 
 @Service
+@Transactional
 class UserService(
     private val userRepository: UserRepository,
     private val refreshTokenRepository: RefreshTokenRepository
 ) {
-
-    @Transactional
     fun withdraw(userId: Long) {
         val user = userRepository.findByIdAndIsDeletedFalse(userId)
             ?: throw UserException(ErrorCode.USER_NOT_FOUND)


### PR DESCRIPTION
## 변경 유형
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
- 액세스토큰 만료시 리프레쉬토큰으로 액세스토큰 재발하는 api 추가
- 액세스토큰 재발급 받으면서 리프레쉬토큰도 갱신
- dto를 request/response로 분리

## 관련링크 (JIRA, Github, etc)
- [SPS-118](https://depromeet-16-5.atlassian.net/browse/SPS-118?atlOrigin=eyJpIjoiOWRlOTdmNTNiNTI2NDM1ZTk3NDdiYzU1YjM1OWU4MDAiLCJwIjoiaiJ9)


[SPS-118]: https://depromeet-16-5.atlassian.net/browse/SPS-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ