### PR TITLE
feat: 기록 저장 API 추가

### DIFF
--- a/clog-api/build.gradle.kts
+++ b/clog-api/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
-    implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
+    implementation("org.hibernate.orm:hibernate-core")
 
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")

--- a/clog-api/build.gradle.kts
+++ b/clog-api/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
 
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptRequest.kt
@@ -1,0 +1,19 @@
+package org.depromeet.clog.server.api.attempt.presentation
+
+import org.depromeet.clog.server.domain.attempt.Attempt
+import org.depromeet.clog.server.domain.attempt.AttemptStatus
+
+data class AttemptRequest(
+    val status: AttemptStatus,
+) {
+    fun toDomain(
+        problemId: Long,
+        videoId: Long,
+    ): Attempt {
+        return Attempt(
+            problemId = problemId,
+            videoId = videoId,
+            status = status,
+        )
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/StampRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/StampRequest.kt
@@ -1,0 +1,14 @@
+package org.depromeet.clog.server.api.attempt.presentation
+
+import org.depromeet.clog.server.domain.video.VideoStamp
+
+data class StampRequest(
+    val timeMs: Long,
+) {
+    fun toDomain(videoId: Long): VideoStamp {
+        return VideoStamp(
+            videoId = videoId,
+            timeMs = timeMs,
+        )
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/VideoRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/VideoRequest.kt
@@ -1,0 +1,20 @@
+package org.depromeet.clog.server.api.attempt.presentation
+
+import org.depromeet.clog.server.domain.video.Video
+
+data class VideoRequest(
+
+    val localPath: String,
+
+    val thumbnailUrl: String,
+
+    val durationMs: Long,
+) {
+    fun toDomain(): Video {
+        return Video(
+            localPath = localPath,
+            thumbnailUrl = thumbnailUrl,
+            durationMs = durationMs,
+        )
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/configuration/UserContextResolver.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/configuration/UserContextResolver.kt
@@ -2,8 +2,8 @@ package org.depromeet.clog.server.api.configuration
 
 import jakarta.servlet.http.HttpServletRequest
 import org.depromeet.clog.server.api.security.jwt.JwtUtils
+import org.depromeet.clog.server.api.user.UserContext
 import org.depromeet.clog.server.domain.auth.application.TokenService
-import org.depromeet.clog.server.domain.user.domain.UserContext
 import org.springframework.core.MethodParameter
 import org.springframework.stereotype.Component
 import org.springframework.web.bind.support.WebDataBinderFactory

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/presentation/ProblemRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/presentation/ProblemRequest.kt
@@ -1,0 +1,18 @@
+package org.depromeet.clog.server.api.problem.presentation
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.depromeet.clog.server.domain.problem.Problem
+
+@Schema(description = "새로운 문제 등록")
+data class ProblemRequest(
+
+    @Schema(description = "난이도 ID", example = "1")
+    val gradeId: Long? = null,
+) {
+    fun toDomain(storyId: Long): Problem {
+        return Problem(
+            storyId = storyId,
+            gradeId = gradeId,
+        )
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/application/SaveStory.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/application/SaveStory.kt
@@ -1,0 +1,46 @@
+package org.depromeet.clog.server.api.story.application
+
+import jakarta.transaction.Transactional
+import org.depromeet.clog.server.api.story.presentation.SaveStoryRequest
+import org.depromeet.clog.server.api.story.presentation.SaveStoryResponse
+import org.depromeet.clog.server.domain.attempt.AttemptRepository
+import org.depromeet.clog.server.domain.problem.ProblemRepository
+import org.depromeet.clog.server.domain.story.StoryRepository
+import org.depromeet.clog.server.domain.video.VideoRepository
+import org.springframework.stereotype.Service
+
+@Service
+class SaveStory(
+    private val storyRepository: StoryRepository,
+    private val problemRepository: ProblemRepository,
+    private val attemptRepository: AttemptRepository,
+    private val videoRepository: VideoRepository,
+) {
+
+    @Transactional
+    operator fun invoke(
+        userId: Long,
+        request: SaveStoryRequest,
+    ): SaveStoryResponse {
+        val story = storyRepository.save(
+            request.toDomain(userId)
+        )
+
+        val problem = problemRepository.save(
+            request.problem.toDomain(story.id!!)
+        )
+
+        val video = videoRepository.save(
+            request.video.toDomain()
+        )
+
+        attemptRepository.save(
+            request.attempt.toDomain(problem.id!!, video.id!!)
+        )
+
+        return SaveStoryResponse(
+            storyId = story.id!!,
+            problemId = problem.id!!,
+        )
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveStoryRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveStoryRequest.kt
@@ -1,0 +1,27 @@
+package org.depromeet.clog.server.api.story.presentation
+
+import org.depromeet.clog.server.api.attempt.presentation.AttemptRequest
+import org.depromeet.clog.server.api.attempt.presentation.VideoRequest
+import org.depromeet.clog.server.api.problem.presentation.ProblemRequest
+import org.depromeet.clog.server.domain.story.Story
+import java.time.LocalDate
+
+data class SaveStoryRequest(
+
+    val cragId: Long? = null,
+
+    val problem: ProblemRequest,
+
+    val attempt: AttemptRequest,
+
+    val video: VideoRequest,
+) {
+
+    fun toDomain(userId: Long): Story {
+        return Story(
+            userId = userId,
+            cragId = cragId,
+            date = LocalDate.now(),
+        )
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveStoryResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveStoryResponse.kt
@@ -1,0 +1,6 @@
+package org.depromeet.clog.server.api.story.presentation
+
+data class SaveStoryResponse(
+    val storyId: Long,
+    val problemId: Long,
+)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/StoryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/StoryController.kt
@@ -1,0 +1,32 @@
+package org.depromeet.clog.server.api.story.presentation
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.api.story.application.SaveStory
+import org.depromeet.clog.server.api.user.UserContext
+import org.depromeet.clog.server.domain.common.ClogApiResponse
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "기록 API")
+@RequestMapping("${ApiConstants.API_BASE_PATH_V1}/stories")
+@RestController
+class StoryController(
+    private val saveStory: SaveStory,
+) {
+
+    @Operation(
+        summary = "기록 저장",
+        description = "기록 최초 저장에 사용됩니다. 첫 번째 시도 종료 후 사용되며, 문제와 시도 정보를 함께 저장합니다.",
+    )
+    @PostMapping
+    fun save(
+        userContext: UserContext,
+        request: SaveStoryRequest,
+    ): ClogApiResponse<SaveStoryResponse> {
+        val result = saveStory(userContext.userId, request)
+        return ClogApiResponse.from(result)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/UserContext.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/UserContext.kt
@@ -1,0 +1,8 @@
+package org.depromeet.clog.server.api.user
+
+import io.swagger.v3.oas.annotations.Hidden
+
+@Hidden
+data class UserContext(
+    val userId: Long,
+)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/application/GetMe.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/application/GetMe.kt
@@ -1,7 +1,7 @@
 package org.depromeet.clog.server.api.user.application
 
+import org.depromeet.clog.server.api.user.UserContext
 import org.depromeet.clog.server.api.user.presentation.UserResponse
-import org.depromeet.clog.server.domain.user.domain.UserContext
 import org.depromeet.clog.server.domain.user.domain.UserRepository
 import org.depromeet.clog.server.domain.user.domain.exception.UserNotFoundException
 import org.springframework.stereotype.Service

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/presentation/UserController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/presentation/UserController.kt
@@ -7,6 +7,10 @@ import org.depromeet.clog.server.domain.auth.application.LogoutService
 import org.depromeet.clog.server.domain.common.ClogApiResponse
 import org.depromeet.clog.server.domain.common.ErrorCode
 import org.depromeet.clog.server.domain.user.application.UserService
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 import org.depromeet.clog.server.domain.user.application.dto.UpdateUserNameReauest
 import org.depromeet.clog.server.domain.user.domain.UserContext
 import org.springframework.web.bind.annotation.*

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/presentation/UserController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/presentation/UserController.kt
@@ -3,17 +3,17 @@ package org.depromeet.clog.server.api.user.presentation
 import io.swagger.v3.oas.annotations.Operation
 import org.depromeet.clog.server.api.configuration.ApiConstants.API_BASE_PATH_V1
 import org.depromeet.clog.server.api.configuration.annotation.ApiErrorCodes
+import org.depromeet.clog.server.api.user.UserContext
 import org.depromeet.clog.server.domain.auth.application.LogoutService
 import org.depromeet.clog.server.domain.common.ClogApiResponse
 import org.depromeet.clog.server.domain.common.ErrorCode
 import org.depromeet.clog.server.domain.user.application.UserService
+import org.depromeet.clog.server.domain.user.application.dto.UpdateUserNameReauest
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import org.depromeet.clog.server.domain.user.application.dto.UpdateUserNameReauest
-import org.depromeet.clog.server.domain.user.domain.UserContext
-import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("$API_BASE_PATH_V1/user")

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/presentation/UserQueryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/presentation/UserQueryController.kt
@@ -4,10 +4,10 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.depromeet.clog.server.api.configuration.ApiConstants
 import org.depromeet.clog.server.api.configuration.annotation.ApiErrorCodes
+import org.depromeet.clog.server.api.user.UserContext
 import org.depromeet.clog.server.api.user.application.GetMe
 import org.depromeet.clog.server.domain.common.ClogApiResponse
 import org.depromeet.clog.server.domain.common.ErrorCode
-import org.depromeet.clog.server.domain.user.domain.UserContext
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/Attempt.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/Attempt.kt
@@ -1,11 +1,12 @@
 package org.depromeet.clog.server.domain.attempt
 
-import org.depromeet.clog.server.domain.video.Video
+import java.time.Instant
 
 data class Attempt(
-    val id: Long = 0L,
-    val video: Video? = null,
+    val id: Long? = null,
+    val problemId: Long,
+    val videoId: Long,
     val status: AttemptStatus,
-    val createdAt: String,
-    val updatedAt: String,
+    val createdAt: Instant? = null,
+    val updatedAt: Instant? = null,
 )

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/AttemptRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/AttemptRepository.kt
@@ -1,0 +1,6 @@
+package org.depromeet.clog.server.domain.attempt
+
+interface AttemptRepository {
+
+    fun save(attempt: Attempt): Attempt
+}

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/crag/domain/CragRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/crag/domain/CragRepository.kt
@@ -2,6 +2,10 @@ package org.depromeet.clog.server.domain.crag.domain
 
 interface CragRepository {
     fun save(crag: Crag): Crag
+
+    fun findById(id: Long): Crag?
+
     fun saveAll(crags: List<Crag>): List<Crag>
+
     fun existsByKakaoPlaceId(kakaoPlaceId: Long): Boolean
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/crag/domain/Grade.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/crag/domain/Grade.kt
@@ -1,6 +1,7 @@
 package org.depromeet.clog.server.domain.crag.domain
 
 data class Grade(
+    val id: Long? = null,
     val color: Color,
     val order: Int? = null,
 )

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/crag/domain/GradeRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/crag/domain/GradeRepository.kt
@@ -1,0 +1,6 @@
+package org.depromeet.clog.server.domain.crag.domain
+
+interface GradeRepository {
+
+    fun findById(id: Long): Grade?
+}

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/problem/Problem.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/problem/Problem.kt
@@ -1,13 +1,11 @@
 package org.depromeet.clog.server.domain.problem
 
-import org.depromeet.clog.server.domain.crag.domain.Crag
-import org.depromeet.clog.server.domain.crag.domain.Grade
+import java.time.Instant
 
 data class Problem(
-    val id: Long,
-    val crag: Crag? = null,
-    val grad: Grade,
-    val tags: List<String>,
-    val createdAt: String,
-    val updatedAt: String
+    val id: Long? = null,
+    val storyId: Long,
+    val gradeId: Long? = null,
+    val createdAt: Instant? = null,
+    val updatedAt: Instant? = null,
 )

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/problem/ProblemRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/problem/ProblemRepository.kt
@@ -1,0 +1,6 @@
+package org.depromeet.clog.server.domain.problem
+
+interface ProblemRepository {
+
+    fun save(problem: Problem): Problem
+}

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/story/Story.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/story/Story.kt
@@ -1,14 +1,14 @@
 package org.depromeet.clog.server.domain.story
 
-import org.depromeet.clog.server.domain.crag.domain.Crag
-import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class Story(
-    val id: Long = 0L,
-    val crag: Crag,
-    val memo: String,
+    val id: Long? = null,
+    val userId: Long,
+    val cragId: Long? = null,
+    val memo: String? = null,
     val date: LocalDate,
-    val createdAt: Instant,
-    val updatedAt: Instant,
+    val createdAt: LocalDateTime? = null,
+    val updatedAt: LocalDateTime? = null,
 )

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/story/StoryRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/story/StoryRepository.kt
@@ -1,0 +1,6 @@
+package org.depromeet.clog.server.domain.story
+
+interface StoryRepository {
+
+    fun save(story: Story): Story
+}

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/user/domain/UserContext.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/user/domain/UserContext.kt
@@ -1,5 +1,0 @@
-package org.depromeet.clog.server.domain.user.domain
-
-data class UserContext(
-    val userId: Long,
-)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/Video.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/Video.kt
@@ -1,13 +1,13 @@
 package org.depromeet.clog.server.domain.video
 
-import java.time.Instant
+import java.time.LocalDateTime
 
 data class Video(
-    val id: Long = 0L,
+    val id: Long? = null,
     val localPath: String,
     val thumbnailUrl: String,
     val durationMs: Long,
-    val createdAt: Instant?,
-    val updatedAt: Instant?,
-    val stamps: List<VideoStamp> = emptyList()
+    val stamps: List<VideoStamp> = emptyList(),
+    val createdAt: LocalDateTime? = null,
+    val modifiedAt: LocalDateTime? = null,
 )

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/VideoRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/VideoRepository.kt
@@ -1,0 +1,6 @@
+package org.depromeet.clog.server.domain.video
+
+interface VideoRepository {
+
+    fun save(video: Video): Video
+}

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/VideoStamp.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/VideoStamp.kt
@@ -1,11 +1,11 @@
 package org.depromeet.clog.server.domain.video
 
-import java.time.Instant
+import java.time.LocalDateTime
 
 data class VideoStamp(
-    val id: Long = 0L,
+    val id: Long? = null,
     val videoId: Long,
     val timeMs: Long,
-    val createdAt: Instant?,
-    val updatedAt: Instant?,
+    val createdAt: LocalDateTime? = null,
+    val modifiedAt: LocalDateTime? = null,
 )

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/.gitkeep
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/.gitkeep
@@ -1,1 +1,0 @@
-please delete this file after you add some code to the package

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptAdapter.kt
@@ -1,0 +1,15 @@
+package org.depromeet.clog.server.infrastructure.attempt
+
+import org.depromeet.clog.server.domain.attempt.Attempt
+import org.depromeet.clog.server.domain.attempt.AttemptRepository
+import org.springframework.stereotype.Component
+
+@Component
+class AttemptAdapter(
+    private val attemptJpaRepository: AttemptJpaRepository,
+) : AttemptRepository {
+
+    override fun save(attempt: Attempt): Attempt {
+        return attemptJpaRepository.save(AttemptEntity.fromDomain(attempt)).toDomain()
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptEntity.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptEntity.kt
@@ -1,0 +1,45 @@
+package org.depromeet.clog.server.infrastructure.attempt
+
+import jakarta.persistence.*
+import org.depromeet.clog.server.domain.attempt.Attempt
+import org.depromeet.clog.server.domain.attempt.AttemptStatus
+import org.depromeet.clog.server.infrastructure.common.BaseEntity
+
+@Table(name = "attempt")
+@Entity
+class AttemptEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    val id: Long? = null,
+
+    @Column(name = "problem_id")
+    val problemId: Long,
+
+    @Column(name = "video_id")
+    val videoId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    val status: AttemptStatus,
+) : BaseEntity() {
+    fun toDomain(): Attempt {
+        return Attempt(
+            id = id,
+            problemId = problemId,
+            videoId = videoId,
+            status = status,
+        )
+    }
+
+    companion object {
+        fun fromDomain(domain: Attempt): AttemptEntity {
+            return AttemptEntity(
+                id = domain.id,
+                problemId = domain.problemId,
+                videoId = domain.videoId,
+                status = domain.status,
+            )
+        }
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptJpaRepository.kt
@@ -1,0 +1,5 @@
+package org.depromeet.clog.server.infrastructure.attempt
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AttemptJpaRepository : JpaRepository<AttemptEntity, Long>

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/CragRepositoryAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/CragRepositoryAdapter.kt
@@ -2,6 +2,7 @@ package org.depromeet.clog.server.infrastructure.crag
 
 import org.depromeet.clog.server.domain.crag.domain.Crag
 import org.depromeet.clog.server.domain.crag.domain.CragRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -19,4 +20,7 @@ class CragRepositoryAdapter(
 
     override fun existsByKakaoPlaceId(kakaoPlaceId: Long): Boolean =
         cragJpaRepository.existsByKakaoPlaceId(kakaoPlaceId)
+
+    override fun findById(id: Long): Crag? =
+        cragJpaRepository.findByIdOrNull(id)?.toDomain()
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeAdapter.kt
@@ -1,0 +1,16 @@
+package org.depromeet.clog.server.infrastructure.crag
+
+import org.depromeet.clog.server.domain.crag.domain.Grade
+import org.depromeet.clog.server.domain.crag.domain.GradeRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class GradeAdapter(
+    private val gradeJpaRepository: GradeJpaRepository,
+) : GradeRepository {
+    override fun findById(id: Long): Grade? {
+        return gradeJpaRepository.findByIdOrNull(id)
+            ?.toDomain()
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeEntity.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeEntity.kt
@@ -1,0 +1,39 @@
+package org.depromeet.clog.server.infrastructure.crag
+
+import jakarta.persistence.*
+import org.depromeet.clog.server.domain.crag.domain.Grade
+
+@Table(name = "grade")
+@Entity
+class GradeEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    val id: Long? = null,
+
+    @JoinColumn(name = "color_id")
+    @ManyToOne(fetch = FetchType.EAGER)
+    val color: ColorEntity,
+
+    @Column(name = "order")
+    val order: Int? = null,
+) {
+
+    fun toDomain(): Grade {
+        return Grade(
+            id = id,
+            color = color.toDomain(),
+            order = order,
+        )
+    }
+
+    companion object {
+        fun fromDomain(grade: Grade): GradeEntity {
+            return GradeEntity(
+                id = grade.id,
+                color = ColorEntity.fromDomain(grade.color),
+                order = grade.order,
+            )
+        }
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeJpaRepository.kt
@@ -1,0 +1,5 @@
+package org.depromeet.clog.server.infrastructure.crag
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GradeJpaRepository : JpaRepository<GradeEntity, Long>

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/problem/ProblemAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/problem/ProblemAdapter.kt
@@ -1,0 +1,15 @@
+package org.depromeet.clog.server.infrastructure.problem
+
+import org.depromeet.clog.server.domain.problem.Problem
+import org.depromeet.clog.server.domain.problem.ProblemRepository
+import org.springframework.stereotype.Component
+
+@Component
+class ProblemAdapter(
+    private val problemJpaRepository: ProblemJpaRepository,
+) : ProblemRepository {
+
+    override fun save(problem: Problem): Problem {
+        return problemJpaRepository.save(ProblemEntity.fromDomain(problem)).toDomain()
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/problem/ProblemEntity.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/problem/ProblemEntity.kt
@@ -1,0 +1,40 @@
+package org.depromeet.clog.server.infrastructure.problem
+
+import jakarta.persistence.*
+import org.depromeet.clog.server.domain.problem.Problem
+import org.depromeet.clog.server.infrastructure.common.BaseEntity
+
+@Table(name = "problem")
+@Entity
+class ProblemEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    val id: Long? = null,
+
+    @Column(name = "story_id")
+    val storyId: Long,
+
+    @Column(name = "grade_id")
+    val gradeId: Long? = null,
+) : BaseEntity() {
+
+    fun toDomain(): Problem {
+        return Problem(
+            id = id,
+            storyId = storyId,
+            gradeId = gradeId,
+        )
+    }
+
+    companion object {
+        fun fromDomain(domain: Problem): ProblemEntity {
+            return ProblemEntity(
+                id = domain.id,
+                storyId = domain.storyId,
+                gradeId = domain.gradeId,
+            )
+        }
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/problem/ProblemJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/problem/ProblemJpaRepository.kt
@@ -1,0 +1,5 @@
+package org.depromeet.clog.server.infrastructure.problem
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProblemJpaRepository : JpaRepository<ProblemEntity, Long>

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryAdapter.kt
@@ -1,0 +1,15 @@
+package org.depromeet.clog.server.infrastructure.story
+
+import org.depromeet.clog.server.domain.story.Story
+import org.depromeet.clog.server.domain.story.StoryRepository
+import org.springframework.stereotype.Component
+
+@Component
+class StoryAdapter(
+    private val storyJpaRepository: StoryJpaRepository,
+) : StoryRepository {
+
+    override fun save(story: Story): Story {
+        return storyJpaRepository.save(StoryEntity.from(story)).toDomain()
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryEntity.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryEntity.kt
@@ -1,0 +1,51 @@
+package org.depromeet.clog.server.infrastructure.story
+
+import jakarta.persistence.*
+import org.depromeet.clog.server.domain.story.Story
+import org.depromeet.clog.server.infrastructure.common.BaseEntity
+import java.time.LocalDate
+
+@Table(name = "story")
+@Entity
+class StoryEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    val id: Long? = null,
+
+    @Column(name = "user_id")
+    val userId: Long,
+
+    @Column(name = "crag_id")
+    val cragId: Long? = null,
+
+    @Column(name = "memo")
+    val memo: String? = null,
+
+    @Column(name = "date")
+    val date: LocalDate,
+) : BaseEntity() {
+    fun toDomain(): Story {
+        return Story(
+            id = id,
+            userId = userId,
+            cragId = cragId,
+            date = date,
+            memo = memo,
+            createdAt = createdAt,
+            updatedAt = modifiedAt,
+        )
+    }
+
+    companion object {
+        fun from(story: Story): StoryEntity {
+            return StoryEntity(
+                id = story.id,
+                userId = story.userId,
+                cragId = story.cragId,
+                date = story.date,
+                memo = story.memo,
+            )
+        }
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryJpaRepository.kt
@@ -1,0 +1,5 @@
+package org.depromeet.clog.server.infrastructure.story
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface StoryJpaRepository : JpaRepository<StoryEntity, Long>

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoAdapter.kt
@@ -1,0 +1,14 @@
+package org.depromeet.clog.server.infrastructure.video
+
+import org.depromeet.clog.server.domain.video.Video
+import org.depromeet.clog.server.domain.video.VideoRepository
+import org.springframework.stereotype.Component
+
+@Component
+class VideoAdapter(
+    private val videoJpaRepository: VideoJpaRepository,
+) : VideoRepository {
+    override fun save(video: Video): Video {
+        return videoJpaRepository.save(VideoEntity.fromDomain(video)).toDomain()
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoEntity.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoEntity.kt
@@ -1,0 +1,46 @@
+package org.depromeet.clog.server.infrastructure.video
+
+import jakarta.persistence.*
+import org.depromeet.clog.server.domain.video.Video
+import org.depromeet.clog.server.infrastructure.common.BaseEntity
+
+@Table(name = "video")
+@Entity
+class VideoEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    val id: Long? = null,
+
+    @Column(name = "local_path")
+    val localPath: String,
+
+    @Column(name = "thumbnail_url")
+    val thumbnailUrl: String,
+
+    @Column(name = "duration_ms")
+    val durationMs: Long,
+) : BaseEntity() {
+    fun toDomain(): Video {
+        return Video(
+            id = id,
+            localPath = localPath,
+            thumbnailUrl = thumbnailUrl,
+            durationMs = durationMs,
+            createdAt = createdAt,
+            modifiedAt = modifiedAt,
+        )
+    }
+
+    companion object {
+        fun fromDomain(video: Video): VideoEntity {
+            return VideoEntity(
+                id = video.id,
+                localPath = video.localPath,
+                thumbnailUrl = video.thumbnailUrl,
+                durationMs = video.durationMs,
+            )
+        }
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoJpaRepository.kt
@@ -1,0 +1,5 @@
+package org.depromeet.clog.server.infrastructure.video
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface VideoJpaRepository : JpaRepository<VideoEntity, Long>

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoStampEntity.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoStampEntity.kt
@@ -1,0 +1,40 @@
+package org.depromeet.clog.server.infrastructure.video
+
+import jakarta.persistence.*
+import org.depromeet.clog.server.domain.video.VideoStamp
+import org.depromeet.clog.server.infrastructure.common.BaseEntity
+
+@Table(name = "video_stamp")
+@Entity
+class VideoStampEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    val id: Long? = null,
+
+    @Column(name = "video_id")
+    val videoId: Long,
+
+    @Column(name = "time_ms")
+    val timeMs: Long,
+) : BaseEntity() {
+    fun toDomain(): VideoStamp {
+        return VideoStamp(
+            id = id,
+            timeMs = timeMs,
+            videoId = videoId,
+            createdAt = createdAt,
+            modifiedAt = modifiedAt,
+        )
+    }
+
+    companion object {
+        fun fromDomain(videoStamp: VideoStamp): VideoStampEntity {
+            return VideoStampEntity(
+                id = videoStamp.id,
+                videoId = videoStamp.videoId,
+                timeMs = videoStamp.timeMs,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 기록 저장 API를 추가합니다.
  - 아래와 같은 도메인의 Repository 및 관련 클래스를 추가합니다.
    - Video
    - Grade
    - Story
    - Problem
    - Attempt
    - VideoStamp

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [SPS-120](https://depromeet-16-5.atlassian.net/browse/SPS-120?atlOrigin=eyJpIjoiNjUxMjUxZjkxNGEyNDExNDhjZmJhNGEzOTUxZmM3MDAiLCJwIjoiaiJ9)


[SPS-120]: https://depromeet-16-5.atlassian.net/browse/SPS-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ