### PR TITLE
feat: 시도 저장 API 추가

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/SaveAttempt.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/SaveAttempt.kt
@@ -1,0 +1,30 @@
+package org.depromeet.clog.server.api.attempt.application
+
+import jakarta.transaction.Transactional
+import org.depromeet.clog.server.api.attempt.presentation.AttemptRequest
+import org.depromeet.clog.server.api.attempt.presentation.AttemptResponse
+import org.depromeet.clog.server.domain.attempt.AttemptRepository
+import org.depromeet.clog.server.domain.video.VideoRepository
+import org.depromeet.clog.server.domain.video.VideoStampRepository
+import org.springframework.stereotype.Service
+
+@Service
+class SaveAttempt(
+    private val attemptRepository: AttemptRepository,
+    private val videoRepository: VideoRepository,
+    private val videoStampRepository: VideoStampRepository,
+) {
+
+    @Transactional
+    operator fun invoke(problemId: Long, request: AttemptRequest): AttemptResponse {
+        val video = videoRepository.save(request.video.toDomain())
+        videoStampRepository.saveAll(
+            request.video.stamps.map { it.toDomain(video.id!!) }
+        )
+        val attempt = attemptRepository.save(
+            request.toDomain(problemId, video.id!!)
+        )
+
+        return AttemptResponse(attempt.id!!)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptController.kt
@@ -1,0 +1,31 @@
+package org.depromeet.clog.server.api.attempt.presentation
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.depromeet.clog.server.api.attempt.application.SaveAttempt
+import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.domain.common.ClogApiResponse
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "시도 API", description = "한 시도(촬영)에 관한 정보를 다룹니다.")
+@RequestMapping("${ApiConstants.API_BASE_PATH_V1}/problems/{problemId}/attempts")
+@RestController
+class AttemptController(
+    private val saveAttempt: SaveAttempt,
+) {
+
+    @Operation(summary = "시도 등록 API")
+    @PostMapping()
+    fun registerAttempt(
+        @PathVariable problemId: Long,
+        @RequestBody @Valid request: AttemptRequest,
+    ): ClogApiResponse<AttemptResponse> {
+        val result = saveAttempt(problemId, request)
+        return ClogApiResponse.from(result)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptRequest.kt
@@ -5,6 +5,8 @@ import org.depromeet.clog.server.domain.attempt.AttemptStatus
 
 data class AttemptRequest(
     val status: AttemptStatus,
+
+    val video: VideoRequest,
 ) {
     fun toDomain(
         problemId: Long,

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptResponse.kt
@@ -1,0 +1,5 @@
+package org.depromeet.clog.server.api.attempt.presentation
+
+data class AttemptResponse(
+    val id: Long,
+)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/VideoRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/VideoRequest.kt
@@ -9,6 +9,8 @@ data class VideoRequest(
     val thumbnailUrl: String,
 
     val durationMs: Long,
+
+    val stamps: List<StampRequest>,
 ) {
     fun toDomain(): Video {
         return Video(

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/application/SaveStory.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/application/SaveStory.kt
@@ -7,6 +7,7 @@ import org.depromeet.clog.server.domain.attempt.AttemptRepository
 import org.depromeet.clog.server.domain.problem.ProblemRepository
 import org.depromeet.clog.server.domain.story.StoryRepository
 import org.depromeet.clog.server.domain.video.VideoRepository
+import org.depromeet.clog.server.domain.video.VideoStampRepository
 import org.springframework.stereotype.Service
 
 @Service
@@ -15,6 +16,7 @@ class SaveStory(
     private val problemRepository: ProblemRepository,
     private val attemptRepository: AttemptRepository,
     private val videoRepository: VideoRepository,
+    private val videoStampRepository: VideoStampRepository,
 ) {
 
     @Transactional
@@ -31,7 +33,11 @@ class SaveStory(
         )
 
         val video = videoRepository.save(
-            request.video.toDomain()
+            request.attempt.video.toDomain()
+        )
+
+        videoStampRepository.saveAll(
+            request.attempt.video.stamps.map { it.toDomain(video.id!!) }
         )
 
         attemptRepository.save(

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveStoryRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveStoryRequest.kt
@@ -1,7 +1,6 @@
 package org.depromeet.clog.server.api.story.presentation
 
 import org.depromeet.clog.server.api.attempt.presentation.AttemptRequest
-import org.depromeet.clog.server.api.attempt.presentation.VideoRequest
 import org.depromeet.clog.server.api.problem.presentation.ProblemRequest
 import org.depromeet.clog.server.domain.story.Story
 import java.time.LocalDate
@@ -13,8 +12,6 @@ data class SaveStoryRequest(
     val problem: ProblemRequest,
 
     val attempt: AttemptRequest,
-
-    val video: VideoRequest,
 ) {
 
     fun toDomain(userId: Long): Story {

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/VideoStampRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/VideoStampRepository.kt
@@ -1,0 +1,6 @@
+package org.depromeet.clog.server.domain.video
+
+interface VideoStampRepository {
+
+    fun saveAll(videoStamps: List<VideoStamp>): List<VideoStamp>
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoStampAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoStampAdapter.kt
@@ -1,0 +1,17 @@
+package org.depromeet.clog.server.infrastructure.video
+
+import org.depromeet.clog.server.domain.video.VideoStamp
+import org.depromeet.clog.server.domain.video.VideoStampRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class VideoStampAdapter(
+    private val videoStampJpaRepository: VideoStampJpaRepository,
+) : VideoStampRepository {
+
+    override fun saveAll(videoStamps: List<VideoStamp>): List<VideoStamp> {
+        return videoStampJpaRepository.saveAll(
+            videoStamps.map { VideoStampEntity.fromDomain(it) }
+        ).map { it.toDomain() }
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoStampJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoStampJpaRepository.kt
@@ -1,0 +1,5 @@
+package org.depromeet.clog.server.infrastructure.video
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface VideoStampJpaRepository : JpaRepository<VideoStampEntity, Long>


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 시도를 저장하는 API를 추가합니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [SPS-123](https://depromeet-16-5.atlassian.net/browse/SPS-123?atlOrigin=eyJpIjoiM2U2ZDc5OTQzNjlhNDI3N2E0ZjVkNTI0NjA2YWNiOWQiLCJwIjoiaiJ9)


[SPS-123]: https://depromeet-16-5.atlassian.net/browse/SPS-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ