### PR TITLE
feat: 문제 저장 API 추가

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/application/SaveProblem.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/application/SaveProblem.kt
@@ -1,0 +1,21 @@
+package org.depromeet.clog.server.api.problem.application
+
+import jakarta.transaction.Transactional
+import org.depromeet.clog.server.api.problem.presentation.ProblemRequest
+import org.depromeet.clog.server.api.problem.presentation.ProblemResponse
+import org.depromeet.clog.server.domain.problem.ProblemRepository
+import org.springframework.stereotype.Service
+
+@Service
+class SaveProblem(
+    private val problemRepository: ProblemRepository,
+) {
+
+    @Transactional
+    operator fun invoke(storyId: Long, request: ProblemRequest): ProblemResponse {
+        val problem = problemRepository.save(
+            request.toDomain(storyId)
+        )
+        return ProblemResponse(problem.id!!)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/presentation/ProblemController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/presentation/ProblemController.kt
@@ -1,0 +1,27 @@
+package org.depromeet.clog.server.api.problem.presentation
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.api.problem.application.SaveProblem
+import org.depromeet.clog.server.domain.common.ClogApiResponse
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "문제 API")
+@RequestMapping("${ApiConstants.API_BASE_PATH_V1}/stories/{storyId}/problems")
+@RestController
+class ProblemController(
+    private val saveProblem: SaveProblem,
+) {
+
+    @Operation(summary = "문제 등록", description = "다음 문제 버튼 클릭 시, 난이도를 지정하고 해당 문제에 대한 영상 촬영 플로우로 넘어갑니다.")
+    @PostMapping
+    fun register(
+        @PathVariable storyId: Long,
+        @RequestBody @Valid request: ProblemRequest,
+    ): ClogApiResponse<ProblemResponse> {
+        val result = saveProblem(storyId, request)
+        return ClogApiResponse.from(result)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/presentation/ProblemResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/presentation/ProblemResponse.kt
@@ -1,0 +1,5 @@
+package org.depromeet.clog.server.api.problem.presentation
+
+data class ProblemResponse(
+    val id: Long,
+)


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 다음 문제 버튼 클릭 시, 문제 정보를 저장하는 API를 추가합니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [SPS-125](https://depromeet-16-5.atlassian.net/browse/SPS-125?atlOrigin=eyJpIjoiMDQ4MTU0MWE3ZTkyNDhlN2FiNmI5NTk1MmVjMTVlOTUiLCJwIjoiaiJ9)


[SPS-125]: https://depromeet-16-5.atlassian.net/browse/SPS-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ