### PR TITLE
feat: 캘린더 메인 조회 API 추가

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/calender/application/GetCalender.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/calender/application/GetCalender.kt
@@ -1,0 +1,21 @@
+package org.depromeet.clog.server.api.calender.application
+
+import org.depromeet.clog.server.domain.calender.Calender
+import org.depromeet.clog.server.domain.calender.CalenderRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetCalender(
+    private val calenderRepository: CalenderRepository,
+) {
+
+    @Transactional(readOnly = true)
+    operator fun invoke(
+        userId: Long,
+        year: Int,
+        month: Int,
+    ): Calender {
+        return calenderRepository.getCalender(userId, year, month)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/calender/controller/CalenderController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/calender/controller/CalenderController.kt
@@ -1,0 +1,38 @@
+package org.depromeet.clog.server.api.calender.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.depromeet.clog.server.api.calender.application.GetCalender
+import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.api.user.UserContext
+import org.depromeet.clog.server.domain.calender.Calender
+import org.depromeet.clog.server.domain.common.ClogApiResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "캘린더 조회 API", description = "캘린더 관련 정보를 조회합니다.")
+@RequestMapping("${ApiConstants.API_BASE_PATH_V1}/calenders")
+@RestController
+class CalenderController(
+    private val getCalender: GetCalender,
+) {
+
+    @Operation(
+        summary = "특정 년/월 캘린더 정보 조회",
+        description = "특정 년/월의 캘린더 메인 화면에 보여져야 하는 정보를 조회합니다.",
+    )
+    @GetMapping
+    fun get(
+        userContext: UserContext,
+        @ModelAttribute query: CalenderQuery,
+    ): ClogApiResponse<Calender> {
+        val result = getCalender(
+            userId = userContext.userId,
+            year = query.year,
+            month = query.month,
+        )
+        return ClogApiResponse.from(result)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/calender/controller/CalenderQuery.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/calender/controller/CalenderQuery.kt
@@ -1,0 +1,14 @@
+package org.depromeet.clog.server.api.calender.controller
+
+import io.swagger.v3.oas.annotations.Parameter
+import org.springdoc.core.annotations.ParameterObject
+
+@ParameterObject
+data class CalenderQuery(
+
+    @Parameter(description = "조회할 년도", example = "2023", required = true)
+    val year: Int,
+
+    @Parameter(description = "조회할 월", example = "10", required = true)
+    val month: Int,
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/calender/Calender.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/calender/Calender.kt
@@ -1,0 +1,16 @@
+package org.depromeet.clog.server.domain.calender
+
+import java.time.LocalDate
+
+data class Calender(
+    val numOfClimbDays: Int,
+    val totalClimbTime: Int,
+    val days: List<Day>,
+) {
+
+    data class Day(
+        val date: LocalDate,
+        val storyIds: List<Long>,
+        val thumbnailUrl: String? = null,
+    )
+}

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/calender/CalenderRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/calender/CalenderRepository.kt
@@ -1,0 +1,20 @@
+package org.depromeet.clog.server.domain.calender
+
+import org.depromeet.clog.server.domain.video.Video
+
+interface CalenderRepository {
+
+    fun getCalender(
+        userId: Long,
+        year: Int,
+        month: Int,
+    ): Calender
+
+    fun calculateTotalClimbTime(
+        userId: Long,
+        year: Int,
+        month: Int,
+    ): Int
+
+    fun findRandomVideoBy(storyId: Long): Video?
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/calender/CalenderAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/calender/CalenderAdapter.kt
@@ -1,0 +1,109 @@
+package org.depromeet.clog.server.infrastructure.calender
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import org.depromeet.clog.server.domain.calender.Calender
+import org.depromeet.clog.server.domain.calender.CalenderRepository
+import org.depromeet.clog.server.domain.video.Video
+import org.depromeet.clog.server.infrastructure.attempt.AttemptEntity
+import org.depromeet.clog.server.infrastructure.problem.ProblemEntity
+import org.depromeet.clog.server.infrastructure.story.StoryEntity
+import org.depromeet.clog.server.infrastructure.story.StoryJpaRepository
+import org.depromeet.clog.server.infrastructure.user.UserEntity
+import org.depromeet.clog.server.infrastructure.video.VideoEntity
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+@Component
+class CalenderAdapter(
+    private val storyJpaRepository: StoryJpaRepository,
+) : CalenderRepository {
+
+    override fun getCalender(userId: Long, year: Int, month: Int): Calender {
+        val storiesOfMonth = storyJpaRepository.findAllByUserIdAndDateGreaterThanEqualAndDateLessThanEqual(
+            userId = userId,
+            startDate = LocalDate.of(year, month, 1),
+            endDate = LocalDate.of(year, month, 1).plusMonths(1),
+        )
+
+        val numOfClimbDays = storiesOfMonth.groupBy { it.date }.size
+        val totalClimbTime = this.calculateTotalClimbTime(userId, year, month)
+
+        storiesOfMonth.let { stories ->
+            val days = stories.groupBy { it.date }.map { (date, stories) ->
+                Calender.Day(
+                    date = date,
+                    storyIds = stories.map { it.id!! },
+                    thumbnailUrl = this.findRandomVideoBy(stories.first().id!!)?.thumbnailUrl
+                )
+            }
+            return Calender(
+                numOfClimbDays = numOfClimbDays,
+                totalClimbTime = totalClimbTime,
+                days = days,
+            )
+        }
+    }
+
+    override fun calculateTotalClimbTime(userId: Long, year: Int, month: Int): Int {
+        return storyJpaRepository.findAll {
+            jpql {
+                select(
+                    sum(
+                        path(VideoEntity::durationMs)
+                    )
+                ).from(
+                    entity(UserEntity::class),
+                    join(StoryEntity::class).on(
+                        path(StoryEntity::userId).eq(path(UserEntity::id))
+                    ),
+                    join(ProblemEntity::class).on(
+                        path(ProblemEntity::storyId).eq(path(StoryEntity::id))
+                    ),
+                    join(AttemptEntity::class).on(
+                        path(AttemptEntity::problemId).eq(path(ProblemEntity::id))
+                    ),
+                    join(VideoEntity::class).on(
+                        path(VideoEntity::id).eq(path(AttemptEntity::videoId))
+                    )
+                ).where(
+                    and(
+                        path(UserEntity::id).eq(userId),
+                        path(StoryEntity::date).between(
+                            LocalDate.of(year, month, 1).minusDays(1),
+                            LocalDate.of(year, month, 1).plusMonths(1)
+                        )
+                    )
+                )
+            }
+        }
+            .first()
+            ?.toInt()
+            ?: 0
+    }
+
+    override fun findRandomVideoBy(storyId: Long): Video? {
+        val page = PageRequest.of(0, 1)
+
+        return storyJpaRepository.findPage(page) {
+            select(
+                entity(VideoEntity::class)
+            ).from(
+                entity(VideoEntity::class),
+                join(AttemptEntity::class).on(
+                    path(AttemptEntity::videoId).eq(path(VideoEntity::id))
+                ),
+                join(ProblemEntity::class).on(
+                    path(ProblemEntity::id).eq(path(AttemptEntity::problemId))
+                ),
+                join(StoryEntity::class).on(
+                    path(StoryEntity::id).eq(path(ProblemEntity::storyId))
+                )
+            ).where(
+                path(StoryEntity::id).eq(storyId)
+            )
+        }
+            .first()
+            ?.toDomain()
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/calender/CalenderAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/calender/CalenderAdapter.kt
@@ -1,6 +1,5 @@
 package org.depromeet.clog.server.infrastructure.calender
 
-import com.linecorp.kotlinjdsl.dsl.jpql.jpql
 import org.depromeet.clog.server.domain.calender.Calender
 import org.depromeet.clog.server.domain.calender.CalenderRepository
 import org.depromeet.clog.server.domain.video.Video
@@ -47,35 +46,33 @@ class CalenderAdapter(
 
     override fun calculateTotalClimbTime(userId: Long, year: Int, month: Int): Int {
         return storyJpaRepository.findAll {
-            jpql {
-                select(
-                    sum(
-                        path(VideoEntity::durationMs)
-                    )
-                ).from(
-                    entity(UserEntity::class),
-                    join(StoryEntity::class).on(
-                        path(StoryEntity::userId).eq(path(UserEntity::id))
-                    ),
-                    join(ProblemEntity::class).on(
-                        path(ProblemEntity::storyId).eq(path(StoryEntity::id))
-                    ),
-                    join(AttemptEntity::class).on(
-                        path(AttemptEntity::problemId).eq(path(ProblemEntity::id))
-                    ),
-                    join(VideoEntity::class).on(
-                        path(VideoEntity::id).eq(path(AttemptEntity::videoId))
-                    )
-                ).where(
-                    and(
-                        path(UserEntity::id).eq(userId),
-                        path(StoryEntity::date).between(
-                            LocalDate.of(year, month, 1).minusDays(1),
-                            LocalDate.of(year, month, 1).plusMonths(1)
-                        )
+            select(
+                sum(
+                    path(VideoEntity::durationMs)
+                )
+            ).from(
+                entity(UserEntity::class),
+                join(StoryEntity::class).on(
+                    path(StoryEntity::userId).eq(path(UserEntity::id))
+                ),
+                join(ProblemEntity::class).on(
+                    path(ProblemEntity::storyId).eq(path(StoryEntity::id))
+                ),
+                join(AttemptEntity::class).on(
+                    path(AttemptEntity::problemId).eq(path(ProblemEntity::id))
+                ),
+                join(VideoEntity::class).on(
+                    path(VideoEntity::id).eq(path(AttemptEntity::videoId))
+                )
+            ).where(
+                and(
+                    path(UserEntity::id).eq(userId),
+                    path(StoryEntity::date).between(
+                        LocalDate.of(year, month, 1).minusDays(1),
+                        LocalDate.of(year, month, 1).plusMonths(1)
                     )
                 )
-            }
+            )
         }
             .first()
             ?.toInt()

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryJpaRepository.kt
@@ -1,5 +1,14 @@
 package org.depromeet.clog.server.infrastructure.story
 
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
 
-interface StoryJpaRepository : JpaRepository<StoryEntity, Long>
+interface StoryJpaRepository : JpaRepository<StoryEntity, Long>, KotlinJdslJpqlExecutor {
+
+    fun findAllByUserIdAndDateGreaterThanEqualAndDateLessThanEqual(
+        userId: Long,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<StoryEntity>
+}


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 캘린더 메인 화면 조회에 사용되는 API를 구현합니다.
<img width="302" alt="스크린샷 2025-03-10 오후 10 58 39" src="https://github.com/user-attachments/assets/e14c682c-27e5-4a0e-9c3b-bb507a44dead" />

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- resolved [[SPS-136](https://depromeet-16-5.atlassian.net/browse/SPS-136?atlOrigin=eyJpIjoiMWQ2Y2RmZDg2YzBlNDg4M2ExNWZkMGU3YmNmYmQyMWYiLCJwIjoiaiJ9)]


[SPS-136]: https://depromeet-16-5.atlassian.net/browse/SPS-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ