### PR TITLE
[SPS-138] 영상 및 시도 정보 수정 API 추가

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/UpdateAttemptAndParents.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/UpdateAttemptAndParents.kt
@@ -1,0 +1,68 @@
+package org.depromeet.clog.server.api.attempt.application
+
+import org.depromeet.clog.server.api.attempt.presentation.AttemptUpdateRequest
+import org.depromeet.clog.server.domain.attempt.Attempt
+import org.depromeet.clog.server.domain.attempt.AttemptNotFoundException
+import org.depromeet.clog.server.domain.attempt.AttemptRepository
+import org.depromeet.clog.server.domain.problem.Problem
+import org.depromeet.clog.server.domain.problem.ProblemRepository
+import org.depromeet.clog.server.domain.story.StoryRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UpdateAttemptAndParents(
+    private val attemptRepository: AttemptRepository,
+    private val problemRepository: ProblemRepository,
+    private val storyRepository: StoryRepository,
+) {
+
+    @Transactional
+    operator fun invoke(
+        attemptId: Long,
+        request: AttemptUpdateRequest
+    ) {
+        val attempt = updateAttempt(attemptId, request)
+        val problem = updateProblem(attempt.problemId, request)
+        updateStory(problem.storyId, request)
+    }
+
+    private fun updateAttempt(attemptId: Long, request: AttemptUpdateRequest): Attempt {
+        val attempt = attemptRepository.findByIdOrNull(attemptId)
+            ?: throw AttemptNotFoundException()
+
+        attemptRepository.save(
+            attempt.copy(
+                status = request.status ?: attempt.status,
+            )
+        )
+        return attempt
+    }
+
+    private fun updateProblem(problemId: Long, request: AttemptUpdateRequest): Problem {
+        val problem = problemRepository.findByIdOrNull(problemId)
+            ?: throw IllegalStateException("Problem not found with id: $problemId")
+
+        problemRepository.save(
+            problem.copy(
+                gradeId = if (request.gradeUnregistered == true) {
+                    null
+                } else {
+                    request.gradeId ?: problem.gradeId
+                },
+            )
+        )
+        return problem
+    }
+
+    private fun updateStory(storyId: Long, request: AttemptUpdateRequest) {
+        val story = storyRepository.findByIdOrNull(storyId)
+            ?: throw IllegalStateException("Story not found with id: $storyId")
+
+        storyRepository.save(
+            story.copy(
+                cragId = request.cragId ?: story.cragId,
+            )
+        )
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptController.kt
@@ -6,11 +6,7 @@ import jakarta.validation.Valid
 import org.depromeet.clog.server.api.attempt.application.SaveAttempt
 import org.depromeet.clog.server.api.configuration.ApiConstants
 import org.depromeet.clog.server.domain.common.ClogApiResponse
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Tag(name = "시도 API", description = "한 시도(촬영)에 관한 정보를 다룹니다.")
 @RequestMapping("${ApiConstants.API_BASE_PATH_V1}/problems/{problemId}/attempts")
@@ -20,7 +16,7 @@ class AttemptController(
 ) {
 
     @Operation(summary = "시도 등록 API")
-    @PostMapping()
+    @PostMapping
     fun registerAttempt(
         @PathVariable problemId: Long,
         @RequestBody @Valid request: AttemptRequest,

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptUpdateController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptUpdateController.kt
@@ -1,0 +1,27 @@
+package org.depromeet.clog.server.api.attempt.presentation
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.depromeet.clog.server.api.attempt.application.UpdateAttemptAndParents
+import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.domain.common.ClogApiResponse
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "시도 API", description = "한 시도(촬영)에 관한 정보를 다룹니다.")
+@RequestMapping("${ApiConstants.API_BASE_PATH_V1}/attempts")
+@RestController
+class AttemptUpdateController(
+    private val updateAttemptAndParents: UpdateAttemptAndParents,
+) {
+
+    @Operation(summary = "시도 수정 API", description = "암장 정보 및 난이도 수정 / 완등 실패 여부 수정에 사용합니다.")
+    @PatchMapping("/{attemptId}")
+    fun update(
+        @PathVariable attemptId: Long,
+        @RequestBody @Valid request: AttemptUpdateRequest,
+    ): ClogApiResponse<Unit> {
+        updateAttemptAndParents(attemptId, request)
+        return ClogApiResponse.from(Unit)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptUpdateRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptUpdateRequest.kt
@@ -1,0 +1,20 @@
+package org.depromeet.clog.server.api.attempt.presentation
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.depromeet.clog.server.domain.attempt.AttemptStatus
+
+@Schema(description = "시도 수정 요청 DTO")
+data class AttemptUpdateRequest(
+
+    @Schema(description = "암장 ID", example = "1")
+    val cragId: Long? = null,
+
+    @Schema(description = "난이도 ID", example = "1")
+    val gradeId: Long? = null,
+
+    @Schema(description = "난이도 미등록으로 변경", example = "true")
+    val gradeUnregistered: Boolean? = null,
+
+    @Schema(description = "완등 여부", example = "FAILURE")
+    val status: AttemptStatus? = null,
+)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/StampRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/StampRequest.kt
@@ -1,8 +1,12 @@
 package org.depromeet.clog.server.api.attempt.presentation
 
+import io.swagger.v3.oas.annotations.media.Schema
 import org.depromeet.clog.server.domain.video.VideoStamp
 
+@Schema(description = "영상 스탬프 요청 DTO")
 data class StampRequest(
+
+    @Schema(description = "영상 스탬프 시간 (ms)", example = "12000")
     val timeMs: Long,
 ) {
     fun toDomain(videoId: Long): VideoStamp {

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/presentation/ProblemController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/presentation/ProblemController.kt
@@ -8,7 +8,7 @@ import org.depromeet.clog.server.api.problem.application.SaveProblem
 import org.depromeet.clog.server.domain.common.ClogApiResponse
 import org.springframework.web.bind.annotation.*
 
-@Tag(name = "문제 API")
+@Tag(name = "문제 API", description = "문제 정보에 관련된 API 목록입니다.")
 @RequestMapping("${ApiConstants.API_BASE_PATH_V1}/stories/{storyId}/problems")
 @RestController
 class ProblemController(

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/video/application/UpdateVideo.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/video/application/UpdateVideo.kt
@@ -1,0 +1,41 @@
+package org.depromeet.clog.server.api.video.application
+
+import org.depromeet.clog.server.api.video.presentation.VideoUpdateRequest
+import org.depromeet.clog.server.domain.video.VideoNotFoundException
+import org.depromeet.clog.server.domain.video.VideoRepository
+import org.depromeet.clog.server.domain.video.VideoStamp
+import org.depromeet.clog.server.domain.video.VideoStampRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UpdateVideo(
+    private val videoRepository: VideoRepository,
+    private val videoStampRepository: VideoStampRepository
+) {
+
+    @Transactional
+    operator fun invoke(
+        videoId: Long,
+        request: VideoUpdateRequest
+    ) {
+        videoRepository.findByIdOrNull(videoId)?.let {
+            videoRepository.save(
+                it.copy(
+                    localPath = request.localPath ?: it.localPath,
+                    thumbnailUrl = request.thumbnailUrl ?: it.thumbnailUrl,
+                    durationMs = request.durationMs,
+                )
+            )
+            videoStampRepository.deleteAllByVideoId(it.id!!)
+            videoStampRepository.saveAll(
+                request.stamps.map { stamp ->
+                    VideoStamp(
+                        videoId = it.id!!,
+                        timeMs = stamp.timeMs,
+                    )
+                }
+            )
+        } ?: throw VideoNotFoundException()
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/video/presentation/VideoController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/video/presentation/VideoController.kt
@@ -1,0 +1,30 @@
+package org.depromeet.clog.server.api.video.presentation
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.api.configuration.annotation.ApiErrorCodes
+import org.depromeet.clog.server.api.video.application.UpdateVideo
+import org.depromeet.clog.server.domain.common.ClogApiResponse
+import org.depromeet.clog.server.domain.common.ErrorCode
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "영상 API", description = "영상 정보에 관련된 API 목록입니다.")
+@RequestMapping("${ApiConstants.API_BASE_PATH_V1}/videos")
+@RestController
+class VideoController(
+    private val updateVideo: UpdateVideo,
+) {
+
+    @ApiErrorCodes([ErrorCode.VIDEO_NOT_FOUND])
+    @Operation(summary = "영상 수정 API", description = "영상 정보를 수정합니다.")
+    @PatchMapping("/{videoId}")
+    fun update(
+        @PathVariable videoId: Long,
+        @RequestBody @Valid request: VideoUpdateRequest
+    ): ClogApiResponse<Unit> {
+        updateVideo(videoId, request)
+        return ClogApiResponse.from(Unit)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/video/presentation/VideoUpdateRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/video/presentation/VideoUpdateRequest.kt
@@ -1,0 +1,20 @@
+package org.depromeet.clog.server.api.video.presentation
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.depromeet.clog.server.api.attempt.presentation.StampRequest
+
+@Schema(description = "영상 수정 요청 DTO")
+data class VideoUpdateRequest(
+
+    @Schema(description = "영상 파일 로컬 경로", example = "1")
+    val localPath: String? = null,
+
+    @Schema(description = "업로드된 썸네일 주소", example = "https://example.com/thumbnail.jpg")
+    val thumbnailUrl: String? = null,
+
+    @Schema(description = "영상 길이 (ms)", example = "12000")
+    val durationMs: Long,
+
+    @Schema(description = "영상 스탬프 목록")
+    val stamps: List<StampRequest>,
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/AttemptNotFoundException.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/AttemptNotFoundException.kt
@@ -1,0 +1,11 @@
+package org.depromeet.clog.server.domain.attempt
+
+import org.depromeet.clog.server.domain.common.ClogException
+import org.depromeet.clog.server.domain.common.ErrorCode
+
+class AttemptNotFoundException(
+    message: String = "시도를 찾을 수 없습니다.",
+) : ClogException(
+    errorCode = ErrorCode.ATTEMPT_NOT_FOUND,
+    message = message,
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/AttemptRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/AttemptRepository.kt
@@ -3,4 +3,5 @@ package org.depromeet.clog.server.domain.attempt
 interface AttemptRepository {
 
     fun save(attempt: Attempt): Attempt
+    fun findByIdOrNull(attemptId: Long): Attempt?
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/common/ErrorCode.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/common/ErrorCode.kt
@@ -15,6 +15,7 @@ enum class ErrorCode(
     TOKEN_EXPIRED("C4011", "토큰이 만료되었습니다.", 401),
     AUTHENTICATION_FAILED("C4012", "인증에 실패하였습니다.", 401),
 
-    // USER
-    USER_NOT_FOUND("C4040", "존재하지 않는 회원입니다.", 404)
+    USER_NOT_FOUND("C4040", "존재하지 않는 회원입니다.", 404),
+    VIDEO_NOT_FOUND("C4041", "존재하지 않는 영상입니다.", 404),
+    ATTEMPT_NOT_FOUND("C4042", "존재하지 않는 시도입니다.", 404),
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/problem/ProblemRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/problem/ProblemRepository.kt
@@ -3,4 +3,6 @@ package org.depromeet.clog.server.domain.problem
 interface ProblemRepository {
 
     fun save(problem: Problem): Problem
+
+    fun findByIdOrNull(problemId: Long): Problem?
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/VideoNotFoundException.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/VideoNotFoundException.kt
@@ -1,0 +1,11 @@
+package org.depromeet.clog.server.domain.video
+
+import org.depromeet.clog.server.domain.common.ClogException
+import org.depromeet.clog.server.domain.common.ErrorCode
+
+class VideoNotFoundException(
+    message: String = "존재하지 않는 영상입니다.",
+) : ClogException(
+    errorCode = ErrorCode.VIDEO_NOT_FOUND,
+    message = message,
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/VideoRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/VideoRepository.kt
@@ -4,4 +4,5 @@ interface VideoRepository {
 
     fun save(video: Video): Video
     fun updateThumbnailUrl(videoId: Long, thumbnailUrl: String): Int
+    fun findByIdOrNull(videoId: Long): Video?
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/VideoStampRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/video/VideoStampRepository.kt
@@ -3,4 +3,5 @@ package org.depromeet.clog.server.domain.video
 interface VideoStampRepository {
 
     fun saveAll(videoStamps: List<VideoStamp>): List<VideoStamp>
+    fun deleteAllByVideoId(videoId: Long)
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptAdapter.kt
@@ -2,6 +2,7 @@ package org.depromeet.clog.server.infrastructure.attempt
 
 import org.depromeet.clog.server.domain.attempt.Attempt
 import org.depromeet.clog.server.domain.attempt.AttemptRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
@@ -11,5 +12,9 @@ class AttemptAdapter(
 
     override fun save(attempt: Attempt): Attempt {
         return attemptJpaRepository.save(AttemptEntity.fromDomain(attempt)).toDomain()
+    }
+
+    override fun findByIdOrNull(attemptId: Long): Attempt? {
+        return attemptJpaRepository.findByIdOrNull(attemptId)?.toDomain()
     }
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeEntity.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeEntity.kt
@@ -15,7 +15,7 @@ class GradeEntity(
     @ManyToOne(fetch = FetchType.EAGER)
     val color: ColorEntity,
 
-    @Column(name = "order")
+    @Column(name = "`order`")
     val order: Int? = null,
 ) {
 

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/problem/ProblemAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/problem/ProblemAdapter.kt
@@ -2,6 +2,7 @@ package org.depromeet.clog.server.infrastructure.problem
 
 import org.depromeet.clog.server.domain.problem.Problem
 import org.depromeet.clog.server.domain.problem.ProblemRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
@@ -11,5 +12,9 @@ class ProblemAdapter(
 
     override fun save(problem: Problem): Problem {
         return problemJpaRepository.save(ProblemEntity.fromDomain(problem)).toDomain()
+    }
+
+    override fun findByIdOrNull(problemId: Long): Problem? {
+        return problemJpaRepository.findByIdOrNull(problemId)?.toDomain()
     }
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoAdapter.kt
@@ -2,6 +2,7 @@ package org.depromeet.clog.server.infrastructure.video
 
 import org.depromeet.clog.server.domain.video.Video
 import org.depromeet.clog.server.domain.video.VideoRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
@@ -14,5 +15,9 @@ class VideoAdapter(
 
     override fun updateThumbnailUrl(videoId: Long, thumbnailUrl: String): Int {
         return videoJpaRepository.updateThumbnailUrl(videoId, thumbnailUrl)
+    }
+
+    override fun findByIdOrNull(videoId: Long): Video? {
+        return videoJpaRepository.findByIdOrNull(videoId)?.toDomain()
     }
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoStampAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoStampAdapter.kt
@@ -14,4 +14,8 @@ class VideoStampAdapter(
             videoStamps.map { VideoStampEntity.fromDomain(it) }
         ).map { it.toDomain() }
     }
+
+    override fun deleteAllByVideoId(videoId: Long) {
+        return videoStampJpaRepository.deleteAllByVideoId(videoId)
+    }
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoStampJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/video/VideoStampJpaRepository.kt
@@ -2,4 +2,7 @@ package org.depromeet.clog.server.infrastructure.video
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface VideoStampJpaRepository : JpaRepository<VideoStampEntity, Long>
+interface VideoStampJpaRepository : JpaRepository<VideoStampEntity, Long> {
+
+    fun deleteAllByVideoId(videoId: Long)
+}


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 영상 정보 수정 시 사용될 API들을 추가합니다.
<img width="968" alt="스크린샷 2025-03-12 오후 11 16 06" src="https://github.com/user-attachments/assets/e5880c0c-68f5-48b5-9daf-28a8bb0b514f" />

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- resolved [[SPS-138](https://depromeet-16-5.atlassian.net/browse/SPS-138?atlOrigin=eyJpIjoiZDlhOTBhOWRhNGYwNDNlZWE2NjhhNTY3NzAzYzA4ZDUiLCJwIjoiaiJ9)]


[SPS-138]: https://depromeet-16-5.atlassian.net/browse/SPS-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ