### PR TITLE
[SPS-139] 시도 삭제 API 추가

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/DeleteAttemptAndParents.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/DeleteAttemptAndParents.kt
@@ -1,0 +1,52 @@
+package org.depromeet.clog.server.api.attempt.application
+
+import org.depromeet.clog.server.domain.attempt.AttemptNotFoundException
+import org.depromeet.clog.server.domain.attempt.AttemptRepository
+import org.depromeet.clog.server.domain.problem.ProblemRepository
+import org.depromeet.clog.server.domain.story.StoryRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class DeleteAttemptAndParents(
+    private val attemptRepository: AttemptRepository,
+    private val problemRepository: ProblemRepository,
+    private val storyRepository: StoryRepository,
+) {
+
+    @Transactional
+    operator fun invoke(attemptId: Long) {
+        val problemId = deleteAttempt(attemptId)
+        val storyId = deleteProblemIfEmpty(problemId)
+        storyId?.let { deleteStoryIfEmpty(it) }
+    }
+
+    private fun deleteAttempt(attemptId: Long): Long {
+        val attempt = attemptRepository.findByIdOrNull(attemptId)
+            ?: throw AttemptNotFoundException()
+
+        attemptRepository.deleteById(attemptId)
+        return attempt.problemId
+    }
+
+    private fun deleteProblemIfEmpty(problemId: Long): Long? {
+        val problem = problemRepository.findByIdOrNull(problemId)
+            ?: throw IllegalStateException("Problem not found with id: $problemId")
+
+        if (problem.attempts.isEmpty()) {
+            problemRepository.deleteById(problemId)
+            return problem.storyId
+        }
+
+        return null
+    }
+
+    private fun deleteStoryIfEmpty(storyId: Long) {
+        val story = storyRepository.findByIdOrNull(storyId)
+            ?: throw IllegalStateException("Story not found with id: $storyId")
+
+        if (story.problems.isEmpty()) {
+            storyRepository.deleteById(storyId)
+        }
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/SaveAttempt.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/SaveAttempt.kt
@@ -1,7 +1,7 @@
 package org.depromeet.clog.server.api.attempt.application
 
-import org.depromeet.clog.server.api.attempt.presentation.AttemptRequest
-import org.depromeet.clog.server.api.attempt.presentation.SaveAttemptResponse
+import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptRequest
+import org.depromeet.clog.server.api.attempt.presentation.dto.SaveAttemptResponse
 import org.depromeet.clog.server.domain.attempt.AttemptRepository
 import org.depromeet.clog.server.domain.video.VideoRepository
 import org.depromeet.clog.server.domain.video.VideoStampRepository

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/UpdateAttemptAndParents.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/UpdateAttemptAndParents.kt
@@ -1,6 +1,6 @@
 package org.depromeet.clog.server.api.attempt.application
 
-import org.depromeet.clog.server.api.attempt.presentation.AttemptUpdateRequest
+import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptUpdateRequest
 import org.depromeet.clog.server.domain.attempt.Attempt
 import org.depromeet.clog.server.domain.attempt.AttemptNotFoundException
 import org.depromeet.clog.server.domain.attempt.AttemptRepository

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptCommandController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptCommandController.kt
@@ -3,18 +3,23 @@ package org.depromeet.clog.server.api.attempt.presentation
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.depromeet.clog.server.api.attempt.application.DeleteAttemptAndParents
 import org.depromeet.clog.server.api.attempt.application.UpdateAttemptAndParents
 import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.api.configuration.annotation.ApiErrorCodes
 import org.depromeet.clog.server.domain.common.ClogApiResponse
+import org.depromeet.clog.server.domain.common.ErrorCode
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "시도 API", description = "한 시도(촬영)에 관한 정보를 다룹니다.")
 @RequestMapping("${ApiConstants.API_BASE_PATH_V1}/attempts")
 @RestController
-class AttemptUpdateController(
+class AttemptCommandController(
     private val updateAttemptAndParents: UpdateAttemptAndParents,
+    private val deleteAttemptAndParents: DeleteAttemptAndParents,
 ) {
 
+    @ApiErrorCodes([ErrorCode.ATTEMPT_NOT_FOUND])
     @Operation(summary = "시도 수정 API", description = "암장 정보 및 난이도 수정 / 완등 실패 여부 수정에 사용합니다.")
     @PatchMapping("/{attemptId}")
     fun update(
@@ -22,6 +27,19 @@ class AttemptUpdateController(
         @RequestBody @Valid request: AttemptUpdateRequest,
     ): ClogApiResponse<Unit> {
         updateAttemptAndParents(attemptId, request)
+        return ClogApiResponse.from(Unit)
+    }
+
+    @ApiErrorCodes([ErrorCode.ATTEMPT_NOT_FOUND])
+    @Operation(
+        summary = "시도 삭제 API",
+        description = "시도를 삭제합니다. 만약 시도의 부모인 문제 혹은 기록의 아이템이 모두 삭제되었다면, 부모도 삭제됩니다."
+    )
+    @DeleteMapping("/{attemptId}")
+    fun delete(
+        @PathVariable attemptId: Long,
+    ): ClogApiResponse<Unit> {
+        deleteAttemptAndParents(attemptId)
         return ClogApiResponse.from(Unit)
     }
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptCommandController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptCommandController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.depromeet.clog.server.api.attempt.application.DeleteAttemptAndParents
 import org.depromeet.clog.server.api.attempt.application.UpdateAttemptAndParents
+import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptUpdateRequest
 import org.depromeet.clog.server.api.configuration.ApiConstants
 import org.depromeet.clog.server.api.configuration.annotation.ApiErrorCodes
 import org.depromeet.clog.server.domain.common.ClogApiResponse

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptController.kt
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.depromeet.clog.server.api.attempt.application.SaveAttempt
+import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptRequest
+import org.depromeet.clog.server.api.attempt.presentation.dto.SaveAttemptResponse
 import org.depromeet.clog.server.api.configuration.ApiConstants
 import org.depromeet.clog.server.domain.common.ClogApiResponse
 import org.springframework.web.bind.annotation.*

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/SaveAttemptResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/SaveAttemptResponse.kt
@@ -1,5 +1,0 @@
-package org.depromeet.clog.server.api.attempt.presentation
-
-data class SaveAttemptResponse(
-    val id: Long,
-)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptRequest.kt
@@ -1,4 +1,4 @@
-package org.depromeet.clog.server.api.attempt.presentation
+package org.depromeet.clog.server.api.attempt.presentation.dto
 
 import org.depromeet.clog.server.domain.attempt.Attempt
 import org.depromeet.clog.server.domain.attempt.AttemptStatus

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptResponse.kt
@@ -1,4 +1,4 @@
-package org.depromeet.clog.server.api.attempt.presentation
+package org.depromeet.clog.server.api.attempt.presentation.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.depromeet.clog.server.domain.attempt.Attempt

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptUpdateRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptUpdateRequest.kt
@@ -1,4 +1,4 @@
-package org.depromeet.clog.server.api.attempt.presentation
+package org.depromeet.clog.server.api.attempt.presentation.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.depromeet.clog.server.domain.attempt.AttemptStatus

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GradeResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GradeResponse.kt
@@ -1,4 +1,4 @@
-package org.depromeet.clog.server.api.attempt.presentation
+package org.depromeet.clog.server.api.attempt.presentation.dto
 
 data class GradeResponse(
     val id: Long,

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/SaveAttemptResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/SaveAttemptResponse.kt
@@ -1,0 +1,5 @@
+package org.depromeet.clog.server.api.attempt.presentation.dto
+
+data class SaveAttemptResponse(
+    val id: Long,
+)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/StampRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/StampRequest.kt
@@ -1,4 +1,4 @@
-package org.depromeet.clog.server.api.attempt.presentation
+package org.depromeet.clog.server.api.attempt.presentation.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.depromeet.clog.server.domain.video.VideoStamp

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/VideoRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/VideoRequest.kt
@@ -1,4 +1,4 @@
-package org.depromeet.clog.server.api.attempt.presentation
+package org.depromeet.clog.server.api.attempt.presentation.dto
 
 import org.depromeet.clog.server.domain.video.Video
 

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/VideoResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/VideoResponse.kt
@@ -1,4 +1,4 @@
-package org.depromeet.clog.server.api.attempt.presentation
+package org.depromeet.clog.server.api.attempt.presentation.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.depromeet.clog.server.domain.video.Video

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/VideoStampResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/VideoStampResponse.kt
@@ -1,4 +1,4 @@
-package org.depromeet.clog.server.api.attempt.presentation
+package org.depromeet.clog.server.api.attempt.presentation.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.depromeet.clog.server.domain.video.VideoStamp

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/presentation/ProblemResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/presentation/ProblemResponse.kt
@@ -1,7 +1,7 @@
 package org.depromeet.clog.server.api.problem.presentation
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.depromeet.clog.server.api.attempt.presentation.AttemptResponse
+import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptResponse
 import org.depromeet.clog.server.domain.attempt.AttemptStatus
 import org.depromeet.clog.server.domain.problem.Problem
 

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveStoryRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveStoryRequest.kt
@@ -1,6 +1,6 @@
 package org.depromeet.clog.server.api.story.presentation
 
-import org.depromeet.clog.server.api.attempt.presentation.AttemptRequest
+import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptRequest
 import org.depromeet.clog.server.api.problem.presentation.ProblemRequest
 import org.depromeet.clog.server.domain.story.Story
 import java.time.LocalDate

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/video/presentation/VideoUpdateRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/video/presentation/VideoUpdateRequest.kt
@@ -1,7 +1,7 @@
 package org.depromeet.clog.server.api.video.presentation
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.depromeet.clog.server.api.attempt.presentation.StampRequest
+import org.depromeet.clog.server.api.attempt.presentation.dto.StampRequest
 
 @Schema(description = "영상 수정 요청 DTO")
 data class VideoUpdateRequest(

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/AttemptRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/AttemptRepository.kt
@@ -4,4 +4,5 @@ interface AttemptRepository {
 
     fun save(attempt: Attempt): Attempt
     fun findByIdOrNull(attemptId: Long): Attempt?
+    fun deleteById(attemptId: Long)
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/problem/ProblemRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/problem/ProblemRepository.kt
@@ -5,4 +5,6 @@ interface ProblemRepository {
     fun save(problem: Problem): Problem
 
     fun findByIdOrNull(problemId: Long): Problem?
+
+    fun deleteById(problemId: Long)
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/story/StoryRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/story/StoryRepository.kt
@@ -15,4 +15,6 @@ interface StoryRepository {
         startDate: LocalDate,
         endDate: LocalDate,
     ): List<Story>
+
+    fun deleteById(storyId: Long)
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptAdapter.kt
@@ -17,4 +17,8 @@ class AttemptAdapter(
     override fun findByIdOrNull(attemptId: Long): Attempt? {
         return attemptJpaRepository.findByIdOrNull(attemptId)?.toDomain()
     }
+
+    override fun deleteById(attemptId: Long) {
+        attemptJpaRepository.deleteById(attemptId)
+    }
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/problem/ProblemAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/problem/ProblemAdapter.kt
@@ -17,4 +17,8 @@ class ProblemAdapter(
     override fun findByIdOrNull(problemId: Long): Problem? {
         return problemJpaRepository.findByIdOrNull(problemId)?.toDomain()
     }
+
+    override fun deleteById(problemId: Long) {
+        return problemJpaRepository.deleteById(problemId)
+    }
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryAdapter.kt
@@ -69,4 +69,8 @@ class StoryAdapter(
             this.findAggregate(it)
         }
     }
+
+    override fun deleteById(storyId: Long) {
+        storyJpaRepository.deleteById(storyId)
+    }
 }


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 영상 삭제 API를 추가합니다.
  - 만약 영상의 부모인 문제, 기록의 자식들이 모두 지워졌다면 해당 부모도 삭제합니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [[SPS-139](https://depromeet-16-5.atlassian.net/browse/SPS-139)]


[SPS-139]: https://depromeet-16-5.atlassian.net/browse/SPS-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ