### PR TITLE
[SPS-148] 폴더(나의 클라이밍 기록) 조회 API 구현

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/GetAttempt.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/GetAttempt.kt
@@ -1,0 +1,28 @@
+package org.depromeet.clog.server.api.attempt.application
+
+import org.depromeet.clog.server.api.attempt.presentation.dto.GetAttemptResponse
+import org.depromeet.clog.server.api.attempt.presentation.dto.toGetAttemptDetailResponse
+import org.depromeet.clog.server.domain.attempt.AttemptRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetAttempt(
+    private val attemptRepository: AttemptRepository
+) {
+
+    @Transactional(readOnly = true)
+    fun getAttemptDetail(
+        userId: Long,
+        attemptFilter: org.depromeet.clog.server.api.attempt.presentation.dto.AttemptFilter
+    ): GetAttemptResponse {
+        val attemptFilter = org.depromeet.clog.server.domain.attempt.dto.AttemptFilter(
+            attemptStatus = attemptFilter.attemptStatus,
+            cragId = attemptFilter.cragId,
+            gradeId = attemptFilter.gradeId
+        )
+        val domainAttempts = attemptRepository.findAttemptsByUserAndFilter(userId, attemptFilter)
+        val apiAttempts = domainAttempts.map { it.toGetAttemptDetailResponse() }
+        return GetAttemptResponse(apiAttempts)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/GetAttempt.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/GetAttempt.kt
@@ -1,5 +1,6 @@
 package org.depromeet.clog.server.api.attempt.application
 
+import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptFilterRequest
 import org.depromeet.clog.server.api.attempt.presentation.dto.GetAttemptResponse
 import org.depromeet.clog.server.api.attempt.presentation.dto.toGetAttemptDetailResponse
 import org.depromeet.clog.server.domain.attempt.AttemptRepository
@@ -14,12 +15,12 @@ class GetAttempt(
     @Transactional(readOnly = true)
     fun getAttemptDetail(
         userId: Long,
-        attemptFilter: org.depromeet.clog.server.api.attempt.presentation.dto.AttemptFilter
+        attemptFilterRequest: AttemptFilterRequest
     ): GetAttemptResponse {
         val attemptFilter = org.depromeet.clog.server.domain.attempt.dto.AttemptFilter(
-            attemptStatus = attemptFilter.attemptStatus,
-            cragId = attemptFilter.cragId,
-            gradeId = attemptFilter.gradeId
+            attemptStatus = attemptFilterRequest.attemptStatus,
+            cragId = attemptFilterRequest.cragId,
+            gradeId = attemptFilterRequest.gradeId
         )
         val domainAttempts = attemptRepository.findAttemptsByUserAndFilter(userId, attemptFilter)
         val apiAttempts = domainAttempts.map { it.toGetAttemptDetailResponse() }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptQueryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptQueryController.kt
@@ -3,7 +3,7 @@ package org.depromeet.clog.server.api.attempt.presentation
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.depromeet.clog.server.api.attempt.application.GetAttempt
-import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptFilter
+import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptFilterRequest
 import org.depromeet.clog.server.api.attempt.presentation.dto.GetAttemptResponse
 import org.depromeet.clog.server.api.configuration.ApiConstants
 import org.depromeet.clog.server.api.user.UserContext
@@ -26,7 +26,7 @@ class AttemptQueryController(
     @GetMapping
     fun getFolder(
         userContext: UserContext,
-        @ModelAttribute filter: AttemptFilter
+        @ModelAttribute filter: AttemptFilterRequest
     ): ClogApiResponse<GetAttemptResponse> {
         val result = getAttempt.getAttemptDetail(userContext.userId, filter)
         return ClogApiResponse.from(result)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptQueryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptQueryController.kt
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "폴더 API", description = "폴더(나의 클라이밍 기록)에 쓰이는 API입니다.")
-@RequestMapping("${ApiConstants.API_BASE_PATH_V1}/folders")
+@RequestMapping("${ApiConstants.API_BASE_PATH_V1}/attempts")
 @RestController
 class AttemptQueryController(
     private val getAttempt: GetAttempt,

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptQueryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptQueryController.kt
@@ -1,0 +1,34 @@
+package org.depromeet.clog.server.api.attempt.presentation
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.depromeet.clog.server.api.attempt.application.GetAttempt
+import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptFilter
+import org.depromeet.clog.server.api.attempt.presentation.dto.GetAttemptResponse
+import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.api.user.UserContext
+import org.depromeet.clog.server.domain.common.ClogApiResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "폴더 API", description = "폴더(나의 클라이밍 기록)에 쓰이는 API입니다.")
+@RequestMapping("${ApiConstants.API_BASE_PATH_V1}/folders")
+@RestController
+class AttemptQueryController(
+    private val getAttempt: GetAttempt,
+) {
+    @Operation(
+        summary = "폴더 조회",
+        description = "나의 클라이밍 기록 조회 (필터: 시도 상태, 암장ID, 난이도ID)"
+    )
+    @GetMapping
+    fun getFolder(
+        userContext: UserContext,
+        @ModelAttribute filter: AttemptFilter
+    ): ClogApiResponse<GetAttemptResponse> {
+        val result = getAttempt.getAttemptDetail(userContext.userId, filter)
+        return ClogApiResponse.from(result)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFilter.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFilter.kt
@@ -1,0 +1,9 @@
+package org.depromeet.clog.server.api.attempt.presentation.dto
+
+import org.depromeet.clog.server.domain.attempt.AttemptStatus
+
+data class AttemptFilter(
+    val attemptStatus: AttemptStatus? = null,
+    val cragId: Long? = null,
+    val gradeId: Long? = null
+)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFilterRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFilterRequest.kt
@@ -2,7 +2,7 @@ package org.depromeet.clog.server.api.attempt.presentation.dto
 
 import org.depromeet.clog.server.domain.attempt.AttemptStatus
 
-data class AttemptFilter(
+data class AttemptFilterRequest(
     val attemptStatus: AttemptStatus? = null,
     val cragId: Long? = null,
     val gradeId: Long? = null

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFolderViewExtensions.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFolderViewExtensions.kt
@@ -12,7 +12,7 @@ fun AttemptFolderView.toGetAttemptDetailResponse(): GetAttemptDetailResponse {
         date = this.date,
         cragName = this.cragName ?: "",
         colorName = this.colorName ?: "",
-        colorHEX = this.colorHex ?: "",
+        colorHex = this.colorHex ?: "",
         status = this.status
     )
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFolderViewExtensions.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFolderViewExtensions.kt
@@ -5,10 +5,12 @@ import org.depromeet.clog.server.domain.attempt.dto.AttemptFolderView
 fun AttemptFolderView.toGetAttemptDetailResponse(): GetAttemptDetailResponse {
     return GetAttemptDetailResponse(
         attemptId = this.attemptId,
-        videoId = this.videoId,
-        videoLocalPath = this.videoLocalPath ?: "",
-        videoThumbnailUrl = this.videoThumbnailUrl ?: "",
-        videoDurationMs = this.videoDurationMs,
+        video = AttemptVideoResponse(
+            id = this.videoId,
+            localPath = this.videoLocalPath ?: "",
+            thumbnailUrl = this.videoThumbnailUrl ?: "",
+            durationMs = this.videoDurationMs
+        ),
         date = this.date,
         cragName = this.cragName ?: "",
         colorName = this.colorName ?: "",

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFolderViewExtensions.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFolderViewExtensions.kt
@@ -4,14 +4,15 @@ import org.depromeet.clog.server.domain.attempt.dto.AttemptFolderView
 
 fun AttemptFolderView.toGetAttemptDetailResponse(): GetAttemptDetailResponse {
     return GetAttemptDetailResponse(
+        attemptId = this.attemptId,
         videoId = this.videoId,
-        videoLocalPath = this.videoLocalPath,
-        videoThumbnailUrl = this.videoThumbnailUrl,
+        videoLocalPath = this.videoLocalPath ?: "",
+        videoThumbnailUrl = this.videoThumbnailUrl ?: "",
         videoDurationMs = this.videoDurationMs,
         date = this.date,
-        cragName = this.cragName,
-        colorName = this.colorName,
-        colorHEX = this.colorHex,
+        cragName = this.cragName ?: "",
+        colorName = this.colorName ?: "",
+        colorHEX = this.colorHex ?: "",
         status = this.status
     )
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFolderViewExtensions.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFolderViewExtensions.kt
@@ -1,0 +1,17 @@
+package org.depromeet.clog.server.api.attempt.presentation.dto
+
+import org.depromeet.clog.server.domain.attempt.dto.AttemptFolderView
+
+fun AttemptFolderView.toGetAttemptDetailResponse(): GetAttemptDetailResponse {
+    return GetAttemptDetailResponse(
+        videoId = this.videoId,
+        videoLocalPath = this.videoLocalPath,
+        videoThumbnailUrl = this.videoThumbnailUrl,
+        videoDurationMs = this.videoDurationMs,
+        date = this.date,
+        cragName = this.cragName,
+        colorName = this.colorName,
+        colorHEX = this.colorHex,
+        status = this.status
+    )
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptVideoResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptVideoResponse.kt
@@ -1,0 +1,14 @@
+package org.depromeet.clog.server.api.attempt.presentation.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class AttemptVideoResponse(
+    @Schema(description = "비디오 id", example = "1")
+    val id: Long,
+    @Schema(description = "비디오 로컬 경로", example = "/videos/record_001.mp4")
+    val localPath: String,
+    @Schema(description = "비디오 썸네일 URL", example = "https://example.com/thumbnail.jpg")
+    val thumbnailUrl: String,
+    @Schema(description = "비디오 길이 (ms)", example = "12000")
+    val durationMs: Long
+)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptDetailResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptDetailResponse.kt
@@ -1,0 +1,26 @@
+package org.depromeet.clog.server.api.attempt.presentation.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.depromeet.clog.server.domain.attempt.AttemptStatus
+import java.time.LocalDate
+
+data class GetAttemptDetailResponse(
+    @Schema(description = "비디오 id", example = "1")
+    val videoId: Long,
+    @Schema(description = "비디오 로컬 경로", example = "/videos/record_001.mp4")
+    val videoLocalPath: String,
+    @Schema(description = "비디오 썸네일 URL", example = "https://example.com/thumbnail.jpg")
+    val videoThumbnailUrl: String,
+    @Schema(description = "비디오 길이 (ms)", example = "12000")
+    val videoDurationMs: Long,
+    @Schema(description = "기록 날짜", example = "2025-03-13")
+    val date: LocalDate,
+    @Schema(description = "암장명", example = "강남 클라이밍 파크")
+    val cragName: String?,
+    @Schema(description = "난이도 색상 이름", example = "블루")
+    val colorName: String?,
+    @Schema(description = "난이도 색상 HEX", example = "#0000ff")
+    val colorHEX: String?,
+    @Schema(description = "완등 성공/실패 여부", example = "SUCCESS")
+    val status: AttemptStatus
+)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptDetailResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptDetailResponse.kt
@@ -22,7 +22,7 @@ data class GetAttemptDetailResponse(
     @Schema(description = "난이도 색상 이름", example = "블루")
     val colorName: String?,
     @Schema(description = "난이도 색상 HEX", example = "#0000ff")
-    val colorHEX: String?,
+    val colorHex: String?,
     @Schema(description = "완등 성공/실패 여부", example = "SUCCESS")
     val status: AttemptStatus
 )

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptDetailResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptDetailResponse.kt
@@ -5,6 +5,8 @@ import org.depromeet.clog.server.domain.attempt.AttemptStatus
 import java.time.LocalDate
 
 data class GetAttemptDetailResponse(
+    @Schema(description = "시도 id", example = "1")
+    val attemptId: Long,
     @Schema(description = "비디오 id", example = "1")
     val videoId: Long,
     @Schema(description = "비디오 로컬 경로", example = "/videos/record_001.mp4")

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptDetailResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptDetailResponse.kt
@@ -7,14 +7,8 @@ import java.time.LocalDate
 data class GetAttemptDetailResponse(
     @Schema(description = "시도 id", example = "1")
     val attemptId: Long,
-    @Schema(description = "비디오 id", example = "1")
-    val videoId: Long,
-    @Schema(description = "비디오 로컬 경로", example = "/videos/record_001.mp4")
-    val videoLocalPath: String,
-    @Schema(description = "비디오 썸네일 URL", example = "https://example.com/thumbnail.jpg")
-    val videoThumbnailUrl: String,
-    @Schema(description = "비디오 길이 (ms)", example = "12000")
-    val videoDurationMs: Long,
+    @Schema(description = "비디오 정보")
+    val video: AttemptVideoResponse,
     @Schema(description = "기록 날짜", example = "2025-03-13")
     val date: LocalDate,
     @Schema(description = "암장명", example = "강남 클라이밍 파크")

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptResponse.kt
@@ -1,0 +1,9 @@
+package org.depromeet.clog.server.api.attempt.presentation.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "폴더(나의 클라이밍 기록) 응답")
+data class GetAttemptResponse(
+    @Schema(description = "시도한 문제 상세정보")
+    val attempts: List<GetAttemptDetailResponse>
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/AttemptRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/AttemptRepository.kt
@@ -1,8 +1,12 @@
 package org.depromeet.clog.server.domain.attempt
 
+import org.depromeet.clog.server.domain.attempt.dto.AttemptFilter
+import org.depromeet.clog.server.domain.attempt.dto.AttemptFolderView
+
 interface AttemptRepository {
 
     fun save(attempt: Attempt): Attempt
     fun findByIdOrNull(attemptId: Long): Attempt?
     fun deleteById(attemptId: Long)
+    fun findAttemptsByUserAndFilter(userId: Long, filter: AttemptFilter): List<AttemptFolderView>
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/dto/AttemptFilter.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/dto/AttemptFilter.kt
@@ -1,0 +1,9 @@
+package org.depromeet.clog.server.domain.attempt.dto
+
+import org.depromeet.clog.server.domain.attempt.AttemptStatus
+
+data class AttemptFilter(
+    val attemptStatus: AttemptStatus? = null,
+    val cragId: Long? = null,
+    val gradeId: Long? = null
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/dto/AttemptFolderView.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/dto/AttemptFolderView.kt
@@ -1,0 +1,16 @@
+package org.depromeet.clog.server.domain.attempt.dto
+
+import org.depromeet.clog.server.domain.attempt.AttemptStatus
+import java.time.LocalDate
+
+data class AttemptFolderView(
+    val videoId: Long,
+    val videoLocalPath: String,
+    val videoThumbnailUrl: String,
+    val videoDurationMs: Long,
+    val date: LocalDate,
+    val cragName: String,
+    val colorName: String,
+    val colorHex: String,
+    val status: AttemptStatus
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/dto/AttemptFolderView.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/dto/AttemptFolderView.kt
@@ -4,6 +4,7 @@ import org.depromeet.clog.server.domain.attempt.AttemptStatus
 import java.time.LocalDate
 
 data class AttemptFolderView(
+    val attemptId: Long,
     val videoId: Long,
     val videoLocalPath: String?,
     val videoThumbnailUrl: String?,

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/dto/AttemptFolderView.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/dto/AttemptFolderView.kt
@@ -5,12 +5,12 @@ import java.time.LocalDate
 
 data class AttemptFolderView(
     val videoId: Long,
-    val videoLocalPath: String,
-    val videoThumbnailUrl: String,
+    val videoLocalPath: String?,
+    val videoThumbnailUrl: String?,
     val videoDurationMs: Long,
     val date: LocalDate,
-    val cragName: String,
-    val colorName: String,
-    val colorHex: String,
+    val cragName: String?,
+    val colorName: String?,
+    val colorHex: String?,
     val status: AttemptStatus
 )

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptAdapter.kt
@@ -2,6 +2,8 @@ package org.depromeet.clog.server.infrastructure.attempt
 
 import org.depromeet.clog.server.domain.attempt.Attempt
 import org.depromeet.clog.server.domain.attempt.AttemptRepository
+import org.depromeet.clog.server.domain.attempt.dto.AttemptFilter
+import org.depromeet.clog.server.domain.attempt.dto.AttemptFolderView
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
@@ -20,5 +22,17 @@ class AttemptAdapter(
 
     override fun deleteById(attemptId: Long) {
         attemptJpaRepository.deleteById(attemptId)
+    }
+
+    override fun findAttemptsByUserAndFilter(
+        userId: Long,
+        filter: AttemptFilter
+    ): List<AttemptFolderView> {
+        return attemptJpaRepository.findAttemptsByUserAndFilter(
+            userId,
+            filter.attemptStatus,
+            filter.cragId,
+            filter.gradeId
+        )
     }
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptJpaRepository.kt
@@ -13,6 +13,7 @@ interface AttemptJpaRepository : JpaRepository<AttemptEntity, Long> {
     @Query(
         """
         SELECT new org.depromeet.clog.server.domain.attempt.dto.AttemptFolderView(
+            a.id,            
             v.id,
             v.localPath,
             v.thumbnailUrl,

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptJpaRepository.kt
@@ -1,8 +1,46 @@
 package org.depromeet.clog.server.infrastructure.attempt
 
+import org.depromeet.clog.server.domain.attempt.AttemptStatus
+import org.depromeet.clog.server.domain.attempt.dto.AttemptFolderView
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface AttemptJpaRepository : JpaRepository<AttemptEntity, Long> {
 
     fun findAllByProblemIdIn(problemIds: List<Long>): List<AttemptEntity>
+
+    @Query(
+        """
+        SELECT new org.depromeet.clog.server.domain.attempt.dto.AttemptFolderView(
+            v.id,
+            v.localPath,
+            v.thumbnailUrl,
+            v.durationMs,
+            s.date,
+            c.name,
+            col.name,
+            col.hex,
+            a.status
+        )
+        FROM AttemptEntity a
+        JOIN ProblemEntity p ON a.problemId = p.id
+        JOIN StoryEntity s ON p.storyId = s.id
+        JOIN VideoEntity v ON a.videoId = v.id
+        LEFT JOIN GradeEntity g ON p.gradeId = g.id
+        LEFT JOIN g.color col
+        LEFT JOIN CragEntity c ON s.cragId = c.id
+        WHERE s.userId = :userId
+          AND (:attemptStatus IS NULL OR a.status = :attemptStatus)
+          AND (:cragId IS NULL OR s.cragId = :cragId)
+          AND (:gradeId IS NULL OR p.gradeId = :gradeId)
+        ORDER BY a.id DESC
+    """
+    )
+    fun findAttemptsByUserAndFilter(
+        @Param("userId") userId: Long,
+        @Param("attemptStatus") attemptStatus: AttemptStatus?,
+        @Param("cragId") cragId: Long?,
+        @Param("gradeId") gradeId: Long?
+    ): List<AttemptFolderView>
 }


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 나의 클라이밍 기록 조회
- gradeId, cragId, attemptStatus로 필터링 가능

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [SPS-148](https://depromeet-16-5.atlassian.net/browse/SPS-148?atlOrigin=eyJpIjoiY2JlZWU5ZDA2NDc2NDE0MDg5MzNiMjljNTY4NDdiOTciLCJwIjoiaiJ9)


[SPS-148]: https://depromeet-16-5.atlassian.net/browse/SPS-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ