### PR TITLE
[SPS-159] 시도 정보 상세 조회 API 추가

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/GetAllAttempts.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/GetAllAttempts.kt
@@ -1,0 +1,29 @@
+package org.depromeet.clog.server.api.attempt.application
+
+import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptFilterRequest
+import org.depromeet.clog.server.api.attempt.presentation.dto.GetMyAttemptsResponse
+import org.depromeet.clog.server.api.attempt.presentation.dto.toGetAttemptDetailResponse
+import org.depromeet.clog.server.domain.attempt.AttemptRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetAllAttempts(
+    private val attemptRepository: AttemptRepository
+) {
+
+    @Transactional(readOnly = true)
+    fun getAttemptDetail(
+        userId: Long,
+        attemptFilterRequest: AttemptFilterRequest
+    ): GetMyAttemptsResponse {
+        val attemptFilter = org.depromeet.clog.server.domain.attempt.dto.AttemptFilter(
+            attemptStatus = attemptFilterRequest.attemptStatus,
+            cragId = attemptFilterRequest.cragId,
+            gradeId = attemptFilterRequest.gradeId
+        )
+        val domainAttempts = attemptRepository.findAttemptsByUserAndFilter(userId, attemptFilter)
+        val apiAttempts = domainAttempts.map { it.toGetAttemptDetailResponse() }
+        return GetMyAttemptsResponse(apiAttempts)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/GetAttempt.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/application/GetAttempt.kt
@@ -1,29 +1,52 @@
 package org.depromeet.clog.server.api.attempt.application
 
-import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptFilterRequest
+import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptDetailResponse
 import org.depromeet.clog.server.api.attempt.presentation.dto.GetAttemptResponse
-import org.depromeet.clog.server.api.attempt.presentation.dto.toGetAttemptDetailResponse
-import org.depromeet.clog.server.domain.attempt.AttemptRepository
+import org.depromeet.clog.server.api.crag.presentation.dto.CragResponse
+import org.depromeet.clog.server.api.grade.presentation.dto.ColorResponse
+import org.depromeet.clog.server.domain.auth.domain.ForbiddenException
+import org.depromeet.clog.server.domain.problem.ProblemQuery
+import org.depromeet.clog.server.domain.story.StoryNotFoundException
+import org.depromeet.clog.server.domain.story.StoryQuery
+import org.depromeet.clog.server.domain.story.StoryRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class GetAttempt(
-    private val attemptRepository: AttemptRepository
+    private val storyRepository: StoryRepository,
 ) {
 
     @Transactional(readOnly = true)
-    fun getAttemptDetail(
-        userId: Long,
-        attemptFilterRequest: AttemptFilterRequest
-    ): GetAttemptResponse {
-        val attemptFilter = org.depromeet.clog.server.domain.attempt.dto.AttemptFilter(
-            attemptStatus = attemptFilterRequest.attemptStatus,
-            cragId = attemptFilterRequest.cragId,
-            gradeId = attemptFilterRequest.gradeId
+    operator fun invoke(attemptId: Long, userId: Long): GetAttemptResponse {
+        val story = fetchStory(attemptId, userId)
+        val problem = fetchProblem(story, attemptId)
+        val attempt = fetchAttempt(problem, attemptId)
+
+        return GetAttemptResponse(
+            storyId = story.id,
+            problemId = problem.id,
+            color = problem.grade?.color?.let { ColorResponse.from(it) },
+            crag = story.crag?.let { CragResponse.from(it) },
+            attempt = AttemptDetailResponse.from(attempt)
         )
-        val domainAttempts = attemptRepository.findAttemptsByUserAndFilter(userId, attemptFilter)
-        val apiAttempts = domainAttempts.map { it.toGetAttemptDetailResponse() }
-        return GetAttemptResponse(apiAttempts)
     }
+
+    private fun fetchStory(attemptId: Long, userId: Long): StoryQuery {
+        val story = storyRepository.findByAttemptId(attemptId)
+            ?: throw StoryNotFoundException("해당 시도에 대한 스토리를 찾을 수 없습니다. (attemptId: $attemptId)")
+
+        if (story.userId != userId) {
+            throw ForbiddenException("해당 시도에 대한 접근 권한이 없습니다.")
+        }
+
+        return story
+    }
+
+    private fun fetchAttempt(problem: ProblemQuery, attemptId: Long) = problem.attempts.find { it.id == attemptId }
+        ?: throw IllegalArgumentException("해당 시도를 찾을 수 없습니다. (attemptId: $attemptId)")
+
+    private fun fetchProblem(story: StoryQuery, attemptId: Long) =
+        story.problems.find { it.attempts.any { attempt -> attempt.id == attemptId } }
+            ?: throw IllegalArgumentException("해당 시도에 대한 문제를 찾을 수 없습니다. (attemptId: $attemptId)")
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptQueryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/AttemptQueryController.kt
@@ -2,33 +2,47 @@ package org.depromeet.clog.server.api.attempt.presentation
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.depromeet.clog.server.api.attempt.application.GetAllAttempts
 import org.depromeet.clog.server.api.attempt.application.GetAttempt
 import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptFilterRequest
 import org.depromeet.clog.server.api.attempt.presentation.dto.GetAttemptResponse
+import org.depromeet.clog.server.api.attempt.presentation.dto.GetMyAttemptsResponse
 import org.depromeet.clog.server.api.configuration.ApiConstants
 import org.depromeet.clog.server.api.user.UserContext
 import org.depromeet.clog.server.domain.common.ClogApiResponse
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.ModelAttribute
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.web.bind.annotation.*
 
-@Tag(name = "폴더 API", description = "폴더(나의 클라이밍 기록)에 쓰이는 API입니다.")
+@Tag(name = "시도 API", description = "한 시도(촬영)에 관한 정보를 다룹니다.")
 @RequestMapping("${ApiConstants.API_BASE_PATH_V1}/attempts")
 @RestController
 class AttemptQueryController(
+    private val getAllAttempts: GetAllAttempts,
     private val getAttempt: GetAttempt,
 ) {
     @Operation(
-        summary = "폴더 조회",
-        description = "나의 클라이밍 기록 조회 (필터: 시도 상태, 암장ID, 난이도ID)"
+        summary = "필터링 기반 시도 조회",
+        description = "폴더 뷰 -> 나의 클라이밍 기록 목록 조회에 사용됩니다. (필터: 시도 상태, 암장ID, 난이도ID)"
     )
     @GetMapping
     fun getFolder(
         userContext: UserContext,
-        @ModelAttribute filter: AttemptFilterRequest
+        @ModelAttribute @ParameterObject filter: AttemptFilterRequest
+    ): ClogApiResponse<GetMyAttemptsResponse> {
+        val result = getAllAttempts.getAttemptDetail(userContext.userId, filter)
+        return ClogApiResponse.from(result)
+    }
+
+    @Operation(
+        summary = "시도 상세 조회",
+        description = "각 시도 별 상세 화면에 사용됩니다."
+    )
+    @GetMapping("/{attemptId}")
+    fun getAttemptDetail(
+        userContext: UserContext,
+        @PathVariable attemptId: Long,
     ): ClogApiResponse<GetAttemptResponse> {
-        val result = getAttempt.getAttemptDetail(userContext.userId, filter)
+        val result = getAttempt(attemptId, userContext.userId)
         return ClogApiResponse.from(result)
     }
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptDetailResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptDetailResponse.kt
@@ -5,7 +5,7 @@ import org.depromeet.clog.server.domain.attempt.AttemptQuery
 import org.depromeet.clog.server.domain.attempt.AttemptStatus
 
 @Schema(description = "문제 시도 응답 DTO")
-data class AttemptResponse(
+data class AttemptDetailResponse(
     @Schema(description = "성공/실패 여부", example = "SUCCESS")
     val status: AttemptStatus,
 
@@ -15,8 +15,8 @@ data class AttemptResponse(
 
     companion object {
 
-        fun from(attemptQuery: AttemptQuery): AttemptResponse {
-            return AttemptResponse(
+        fun from(attemptQuery: AttemptQuery): AttemptDetailResponse {
+            return AttemptDetailResponse(
                 status = attemptQuery.status,
                 video = VideoResponse.from(attemptQuery.video),
             )

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptResponse.kt
@@ -1,9 +1,23 @@
 package org.depromeet.clog.server.api.attempt.presentation.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.depromeet.clog.server.api.crag.presentation.dto.CragResponse
+import org.depromeet.clog.server.api.grade.presentation.dto.ColorResponse
 
-@Schema(description = "폴더(나의 클라이밍 기록) 응답")
+@Schema(description = "시도 상세 조회 응답")
 data class GetAttemptResponse(
-    @Schema(description = "시도한 문제 상세정보")
-    val attempts: List<GetAttemptDetailResponse>
+    @Schema(description = "기록 ID", example = "1")
+    val storyId: Long,
+
+    @Schema(description = "문제 ID", example = "1")
+    val problemId: Long,
+
+    @Schema(description = "해당 문제 난이도의 색상 정보")
+    val color: ColorResponse? = null,
+
+    @Schema(description = "해당 시도의 암장 관련 정보")
+    val crag: CragResponse? = null,
+
+    @Schema(description = "해당 시도의 상세 정보")
+    val attempt: AttemptDetailResponse
 )

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetMyAttemptsResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetMyAttemptsResponse.kt
@@ -1,0 +1,9 @@
+package org.depromeet.clog.server.api.attempt.presentation.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "폴더(나의 클라이밍 기록) 응답")
+data class GetMyAttemptsResponse(
+    @Schema(description = "시도한 문제 상세정보")
+    val attempts: List<GetAttemptDetailResponse>
+)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/crag/application/GetMyCrag.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/crag/application/GetMyCrag.kt
@@ -1,6 +1,6 @@
 package org.depromeet.clog.server.api.crag.application
 
-import org.depromeet.clog.server.api.crag.presentation.dto.GetMyCragInfoResponse
+import org.depromeet.clog.server.api.crag.presentation.dto.CragResponse
 import org.depromeet.clog.server.api.crag.presentation.dto.toGetMyCragInfoResponse
 import org.depromeet.clog.server.domain.crag.domain.Crag
 import org.depromeet.clog.server.domain.crag.domain.CragRepository
@@ -18,7 +18,7 @@ class GetMyCrag(
         userId: Long,
         cursor: Long?,
         pageSize: Int
-    ): PagedResponse<GetMyCragInfoResponse> {
+    ): PagedResponse<CragResponse> {
         val domainCrags: List<Crag> =
             cragRepository.findDistinctCragsByUserId(userId, cursor, pageSize + 1)
         val hasMore = domainCrags.size > pageSize

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/crag/presentation/CragQueryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/crag/presentation/CragQueryController.kt
@@ -4,11 +4,12 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.depromeet.clog.server.api.configuration.ApiConstants
 import org.depromeet.clog.server.api.crag.application.GetMyCrag
-import org.depromeet.clog.server.api.crag.presentation.dto.GetMyCragInfoResponse
+import org.depromeet.clog.server.api.crag.presentation.dto.CragResponse
 import org.depromeet.clog.server.api.user.UserContext
 import org.depromeet.clog.server.domain.common.ClogApiResponse
 import org.depromeet.clog.server.global.utils.dto.CursorPageRequest
 import org.depromeet.clog.server.global.utils.dto.PagedResponse
+import org.springdoc.core.annotations.ParameterObject
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.RequestMapping
@@ -27,9 +28,9 @@ class CragQueryController(
     @GetMapping("/me")
     fun getRecordedCrags(
         userContext: UserContext,
-        @ModelAttribute pageRequest: CursorPageRequest
-    ): ClogApiResponse<PagedResponse<GetMyCragInfoResponse>> {
-        val pagedResponse: PagedResponse<GetMyCragInfoResponse> =
+        @ModelAttribute @ParameterObject pageRequest: CursorPageRequest
+    ): ClogApiResponse<PagedResponse<CragResponse>> {
+        val pagedResponse: PagedResponse<CragResponse> =
             getMyCrag.getMyCrags(userContext.userId, pageRequest.cursor, pageRequest.pageSize)
         return ClogApiResponse.from(pagedResponse)
     }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/crag/presentation/dto/CragExtensions.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/crag/presentation/dto/CragExtensions.kt
@@ -2,8 +2,8 @@ package org.depromeet.clog.server.api.crag.presentation.dto
 
 import org.depromeet.clog.server.domain.crag.domain.Crag
 
-fun Crag.toGetMyCragInfoResponse(): GetMyCragInfoResponse {
-    return GetMyCragInfoResponse(
+fun Crag.toGetMyCragInfoResponse(): CragResponse {
+    return CragResponse(
         id = this.id!!,
         name = this.name,
         roadAddress = this.roadAddress

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/crag/presentation/dto/CragResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/crag/presentation/dto/CragResponse.kt
@@ -1,13 +1,25 @@
 package org.depromeet.clog.server.api.crag.presentation.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.depromeet.clog.server.domain.crag.domain.Crag
 
-@Schema(description = "내가 기록한 암장정보 응답 DTO")
-data class GetMyCragInfoResponse(
+@Schema(description = "암장 정보 응답 DTO")
+data class CragResponse(
     @Schema(description = "암장 id", example = "1")
     val id: Long,
     @Schema(description = "암장명", example = "강남 클라이밍 파크")
     val name: String,
     @Schema(description = "도로명 주소", example = "서울특별시 강남구 테헤란로 152")
     val roadAddress: String
-)
+) {
+
+    companion object {
+        fun from(crag: Crag): CragResponse {
+            return CragResponse(
+                id = crag.id!!,
+                name = crag.name,
+                roadAddress = crag.roadAddress
+            )
+        }
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/presentation/GradeQueryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/presentation/GradeQueryController.kt
@@ -9,6 +9,7 @@ import org.depromeet.clog.server.api.user.UserContext
 import org.depromeet.clog.server.domain.common.ClogApiResponse
 import org.depromeet.clog.server.global.utils.dto.CursorPageRequest
 import org.depromeet.clog.server.global.utils.dto.PagedResponse
+import org.springdoc.core.annotations.ParameterObject
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.RequestMapping
@@ -27,7 +28,7 @@ class GradeQueryController(
     @GetMapping("/me")
     fun getRecordedGrades(
         userContext: UserContext,
-        @ModelAttribute pageRequest: CursorPageRequest
+        @ModelAttribute @ParameterObject pageRequest: CursorPageRequest
     ): ClogApiResponse<PagedResponse<GetMyGradeInfoResponse>> {
         val pagedResponse: PagedResponse<GetMyGradeInfoResponse> =
             getMyGrade.getMyGrades(

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/presentation/dto/ColorResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/presentation/dto/ColorResponse.kt
@@ -1,0 +1,27 @@
+package org.depromeet.clog.server.api.grade.presentation.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.depromeet.clog.server.domain.crag.domain.color.Color
+
+@Schema(description = "난이도의 색상 정보입니다.")
+data class ColorResponse(
+    @Schema(description = "색상 ID", example = "1")
+    val id: Long,
+
+    @Schema(description = "색상 이름", example = "노랑")
+    val name: String,
+
+    @Schema(description = "색상 HEX 코드", example = "#FF0000")
+    val hex: String,
+) {
+
+    companion object {
+        fun from(color: Color): ColorResponse {
+            return ColorResponse(
+                id = color.id ?: 0L,
+                name = color.name,
+                hex = color.hex,
+            )
+        }
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/presentation/ProblemResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/problem/presentation/ProblemResponse.kt
@@ -1,7 +1,7 @@
 package org.depromeet.clog.server.api.problem.presentation
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptResponse
+import org.depromeet.clog.server.api.attempt.presentation.dto.AttemptDetailResponse
 import org.depromeet.clog.server.domain.attempt.AttemptStatus
 import org.depromeet.clog.server.domain.problem.ProblemQuery
 
@@ -11,7 +11,7 @@ data class ProblemResponse(
     val id: Long,
 
     @Schema(description = "문제 시도 목록")
-    val attempts: List<AttemptResponse>,
+    val attempts: List<AttemptDetailResponse>,
 
     @Schema(description = "문제 성공 횟수", example = "3")
     val successCount: Int,
@@ -24,7 +24,7 @@ data class ProblemResponse(
 ) {
     companion object {
         fun from(problem: ProblemQuery): ProblemResponse {
-            val attempts = problem.attempts.map { AttemptResponse.from(it) }
+            val attempts = problem.attempts.map { AttemptDetailResponse.from(it) }
             val successCount = attempts.count { it.status == AttemptStatus.SUCCESS }
             val failCount = attempts.count { it.status == AttemptStatus.FAILURE }
             val colorHex = problem.grade?.color?.hex

--- a/clog-global-utils/src/main/kotlin/org/depromeet/clog/server/global/utils/dto/CursorPageRequest.kt
+++ b/clog-global-utils/src/main/kotlin/org/depromeet/clog/server/global/utils/dto/CursorPageRequest.kt
@@ -1,12 +1,13 @@
 package org.depromeet.clog.server.global.utils.dto
 
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "커서 기반 페이지네이션을 위한 요청 DTO")
 data class CursorPageRequest(
-    @Schema(example = "100000")
+    @Parameter(example = "100000")
     val cursor: Long? = null,
 
-    @Schema(example = "10")
+    @Parameter(example = "10")
     val pageSize: Int = 10
 )

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryAdapter.kt
@@ -46,7 +46,7 @@ class StoryAdapter(
             ).from(
                 entity(StoryEntity::class),
                 fetchJoin(StoryEntity::problems),
-                fetchJoin(ProblemEntity::attempts),
+                join(ProblemEntity::attempts),
             ).where(
                 path(AttemptEntity::id).eq(attemptId),
             )


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [x] 버그 수정
- [x] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 시도 상세 정보 조회 API를 추가합니다.
- 몇 DTO를 재활용하기 위해, 네이밍을 통일성있게 수정합니다.
- fetchJoin 두 번 하면 `MultipleBagFetchException` 에러가 발생하는 이슈를 수정합니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [[SPS-159](https://depromeet-16-5.atlassian.net/browse/SPS-159)]


[SPS-159]: https://depromeet-16-5.atlassian.net/browse/SPS-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ