### PR TITLE
[SPS-164] 폴더 API 응답 내 crag, color response 추가

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFolderViewExtensions.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/AttemptFolderViewExtensions.kt
@@ -1,5 +1,7 @@
 package org.depromeet.clog.server.api.attempt.presentation.dto
 
+import org.depromeet.clog.server.api.crag.presentation.dto.CragResponse
+import org.depromeet.clog.server.api.grade.presentation.dto.ColorResponse
 import org.depromeet.clog.server.domain.attempt.dto.AttemptFolderView
 
 fun AttemptFolderView.toGetAttemptDetailResponse(): GetAttemptDetailResponse {
@@ -12,9 +14,20 @@ fun AttemptFolderView.toGetAttemptDetailResponse(): GetAttemptDetailResponse {
             durationMs = this.videoDurationMs
         ),
         date = this.date,
-        cragName = this.cragName ?: "",
-        colorName = this.colorName ?: "",
-        colorHex = this.colorHex ?: "",
+        crag = this.cragId?.let {
+            CragResponse(
+                id = it,
+                name = this.cragName!!,
+                roadAddress = this.cragRoadAddress!!
+            )
+        },
+        color = this.colorId?.let {
+            ColorResponse(
+                id = it,
+                name = this.colorName!!,
+                hex = this.colorHex!!
+            )
+        },
         status = this.status
     )
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptDetailResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/attempt/presentation/dto/GetAttemptDetailResponse.kt
@@ -1,6 +1,8 @@
 package org.depromeet.clog.server.api.attempt.presentation.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.depromeet.clog.server.api.crag.presentation.dto.CragResponse
+import org.depromeet.clog.server.api.grade.presentation.dto.ColorResponse
 import org.depromeet.clog.server.domain.attempt.AttemptStatus
 import java.time.LocalDate
 
@@ -11,12 +13,10 @@ data class GetAttemptDetailResponse(
     val video: AttemptVideoResponse,
     @Schema(description = "기록 날짜", example = "2025-03-13")
     val date: LocalDate,
-    @Schema(description = "암장명", example = "강남 클라이밍 파크")
-    val cragName: String?,
-    @Schema(description = "난이도 색상 이름", example = "블루")
-    val colorName: String?,
-    @Schema(description = "난이도 색상 HEX", example = "#0000ff")
-    val colorHex: String?,
+    @Schema(description = "암장 관련 정보")
+    val crag: CragResponse? = null,
+    @Schema(description = "난이도 색상 관련 정보")
+    val color: ColorResponse? = null,
     @Schema(description = "완등 성공/실패 여부", example = "SUCCESS")
     val status: AttemptStatus
 )

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/dto/AttemptFolderView.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/dto/AttemptFolderView.kt
@@ -10,7 +10,10 @@ data class AttemptFolderView(
     val videoThumbnailUrl: String?,
     val videoDurationMs: Long,
     val date: LocalDate,
+    val cragId: Long?,
     val cragName: String?,
+    val cragRoadAddress: String?,
+    val colorId: Long?,
     val colorName: String?,
     val colorHex: String?,
     val status: AttemptStatus

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/attempt/AttemptJpaRepository.kt
@@ -17,7 +17,10 @@ interface AttemptJpaRepository : JpaRepository<AttemptEntity, Long> {
             v.thumbnailUrl,
             v.durationMs,
             s.date,
+            c.id,
             c.name,
+            c.roadAddress,
+            col.id,
             col.name,
             col.hex,
             a.status


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 폴더 API에 암장 주소가 빠져서, 추가합니다.
  - 넣는 김에, 기존에 있던 `CragResponse`와 `ColorResponse`를 재활용하도록 수정합니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [[SPS-164](https://depromeet-16-5.atlassian.net/browse/SPS-164)]


[SPS-164]: https://depromeet-16-5.atlassian.net/browse/SPS-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ