### PR TITLE
refactor : 액세스토큰 만료시간 조정

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/presentation/UserController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/presentation/UserController.kt
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "유저 API", description = "유저 관련 작업을 수행합니다.")
 @RestController
-@RequestMapping("$API_BASE_PATH_V1/user")
+@RequestMapping("$API_BASE_PATH_V1/users")
 class UserController(
     private val userService: UserService,
     private val logoutService: LogoutService

--- a/clog-api/src/main/resources/application.yml
+++ b/clog-api/src/main/resources/application.yml
@@ -38,7 +38,7 @@ decorator:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expiration-millis: 3600000
+  access-token-expiration-millis: 86400000
   refresh-token-expiration-millis: 604800000
 
 apple:


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 액세스 토큰 유효시간을 : 1시간 -> 24시간으로 변경하였습니다.
- 리프레쉬 토큰 7일 / 액세스토큰 24시간

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

