### PR TITLE
[SPS-167] 암장 난이도 조회 API 추가

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/application/GetCragGrade.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/application/GetCragGrade.kt
@@ -1,0 +1,24 @@
+package org.depromeet.clog.server.api.grade.application
+
+import org.depromeet.clog.server.api.grade.presentation.dto.GetGradeResponse
+import org.depromeet.clog.server.api.grade.presentation.dto.GradesResponse
+import org.depromeet.clog.server.domain.crag.domain.grade.GradeRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetCragGrade(
+    private val gradeRepository: GradeRepository
+) {
+
+    @Transactional(readOnly = true)
+    operator fun invoke(
+        cragId: Long,
+    ): GradesResponse {
+        val grades = gradeRepository.findGradesByCragId(cragId)
+
+        return GradesResponse(
+            grades.map { GetGradeResponse.from(it) }
+        )
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/presentation/GradeQueryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/presentation/GradeQueryController.kt
@@ -5,26 +5,42 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.depromeet.clog.server.api.configuration.ApiConstants
 import org.depromeet.clog.server.api.grade.application.GetMyGrade
 import org.depromeet.clog.server.api.grade.presentation.dto.GetMyGradeInfoResponse
+import org.depromeet.clog.server.api.grade.presentation.dto.GradesResponse
 import org.depromeet.clog.server.api.user.UserContext
 import org.depromeet.clog.server.domain.common.ClogApiResponse
 import org.depromeet.clog.server.global.utils.dto.CursorPagination
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "난이도 조회 API", description = "난이도 정보를 조회할 때 사용하는 API입니다.")
-@RequestMapping("${ApiConstants.API_BASE_PATH_V1}/grades")
+@RequestMapping(ApiConstants.API_BASE_PATH_V1)
 @RestController
 class GradeQueryController(
-    private val getMyGrade: GetMyGrade
+    private val getMyGrade: GetMyGrade,
+    private val getCragGrade: GetCragGrade
 ) {
+
+    @Operation(
+        summary = "암장에 포함된 난이도 정보 조회",
+        description = "암장에 포함된 난이도 정보를 조회합니다."
+    )
+    @GetMapping("/{cragId}/grades")
+    fun getCragGrades(
+        @PathVariable("cragId") cragId: Long
+    ): ClogApiResponse<GradesResponse> {
+        val result = getCragGrade(cragId)
+        return ClogApiResponse.from(result)
+    }
+
     @Operation(
         summary = "내 난이도 정보 조회",
         description = "현재 사용자가 기록한 난이도 정보를 조회합니다."
     )
-    @GetMapping("/me")
+    @GetMapping("/grades/me")
     fun getRecordedGrades(
         userContext: UserContext,
         @ModelAttribute @ParameterObject request: CursorPagination.GeneralRequest<Long>

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/presentation/GradeQueryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/presentation/GradeQueryController.kt
@@ -3,6 +3,7 @@ package org.depromeet.clog.server.api.grade.presentation
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.api.grade.application.GetCragGrade
 import org.depromeet.clog.server.api.grade.application.GetMyGrade
 import org.depromeet.clog.server.api.grade.presentation.dto.GetMyGradeInfoResponse
 import org.depromeet.clog.server.api.grade.presentation.dto.GradesResponse

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/presentation/dto/GetGradeResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/presentation/dto/GetGradeResponse.kt
@@ -1,0 +1,31 @@
+package org.depromeet.clog.server.api.grade.presentation.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.depromeet.clog.server.domain.crag.domain.grade.Grade
+
+@Schema(description = "난이도 응답 DTO")
+data class GetGradeResponse(
+    @Schema(description = "난이도 ID", example = "1")
+    val gradeId: Long,
+
+    @Schema(description = "난이도", example = "1")
+    val order: Int,
+
+    @Schema(description = "난이도 색상 정보")
+    val color: ColorResponse
+) {
+
+    companion object {
+        fun from(grade: Grade): GetGradeResponse {
+            return GetGradeResponse(
+                gradeId = grade.id!!,
+                order = grade.order!!,
+                color = ColorResponse(
+                    id = grade.color.id!!,
+                    name = grade.color.name,
+                    hex = grade.color.hex
+                )
+            )
+        }
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/presentation/dto/GradesResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/grade/presentation/dto/GradesResponse.kt
@@ -1,0 +1,9 @@
+package org.depromeet.clog.server.api.grade.presentation.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "암장에 포함된 난이도 응답")
+data class GradesResponse(
+    @Schema(description = "암장에 포함된 난이도")
+    val grades: List<GetGradeResponse>
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/crag/domain/grade/GradeRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/crag/domain/grade/GradeRepository.kt
@@ -9,4 +9,6 @@ interface GradeRepository {
         cursor: Long?,
         pageSize: Int
     ): List<Grade>
+
+    fun findGradesByCragId(cragId: Long): List<Grade>
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/auth/RefreshTokenAdapter.kt
@@ -6,7 +6,7 @@ import org.depromeet.clog.server.domain.user.domain.Provider
 import org.springframework.stereotype.Component
 
 @Component
-class RefreshTokenRepositoryAdapter(
+class RefreshTokenAdapter(
     private val refreshTokenJpaRepository: RefreshTokenJpaRepository
 ) : RefreshTokenRepository {
 

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/CragAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/CragAdapter.kt
@@ -10,7 +10,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
-class CragRepositoryAdapter(
+class CragAdapter(
     private val cragMapper: CragMapper,
     private val locationMapper: LocationMapper,
     private val cragJpaRepository: CragJpaRepository

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeAdapter.kt
@@ -34,9 +34,11 @@ class GradeAdapter(
             select(
                 entity(GradeEntity::class)
             ).from(
-                entity(GradeEntity::class)
+                entity(GradeEntity::class),
+                fetchJoin(GradeEntity::crag),
+                fetchJoin(GradeEntity::color)
             ).where(
-                path(GradeEntity::crag).path(CragEntity::id).eq(cragId)
+                path(CragEntity::id).eq(cragId)
             )
         }
             .filterNotNull()

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeAdapter.kt
@@ -28,4 +28,19 @@ class GradeAdapter(
         return gradeJpaRepository.findDistinctGradesByUserIdWithCursor(userId, cursor, pageable)
             .map { gradeMapper.toDomain(it) }
     }
+
+    override fun findGradesByCragId(cragId: Long): List<Grade> {
+        val entities = gradeJpaRepository.findAll {
+            select(
+                entity(GradeEntity::class)
+            ).from(
+                entity(GradeEntity::class)
+            ).where(
+                path(GradeEntity::crag).path(CragEntity::id).eq(cragId)
+            )
+        }
+            .filterNotNull()
+
+        return entities.map { gradeMapper.toDomain(it) }
+    }
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/GradeJpaRepository.kt
@@ -1,11 +1,12 @@
 package org.depromeet.clog.server.infrastructure.crag
 
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface GradeJpaRepository : JpaRepository<GradeEntity, Long> {
+interface GradeJpaRepository : JpaRepository<GradeEntity, Long>, KotlinJdslJpqlExecutor {
 
     @Query(
         """

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/RegionAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/RegionAdapter.kt
@@ -6,9 +6,10 @@ import org.depromeet.clog.server.domain.crag.domain.region.RegionRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-class RegionRepositoryAdapter(
+class RegionAdapter(
     private val regionJpaRepository: RegionJpaRepository
 ) : RegionRepository {
+
     override fun findByRegionName(regionName: RegionName): List<Region> =
         regionJpaRepository.findByRegionName(regionName)
             .toList()

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/ThumbnailAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/ThumbnailAdapter.kt
@@ -5,9 +5,10 @@ import org.depromeet.clog.server.domain.thumbnail.ThumbnailRepository
 import org.springframework.stereotype.Component
 
 @Component
-class ThumbnailRepositoryAdapter(
+class ThumbnailAdapter(
     private val thumbnailJpaRepository: ThumbnailJpaRepository
 ) : ThumbnailRepository {
+
     override fun save(thumbnail: Thumbnail): Thumbnail {
         val entity = ThumbnailEntity.fromDomain(thumbnail)
         val savedEntity = thumbnailJpaRepository.save(entity)

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/user/UserAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/user/UserAdapter.kt
@@ -7,7 +7,7 @@ import org.depromeet.clog.server.infrastructure.mappers.UserMapper
 import org.springframework.stereotype.Component
 
 @Component
-class UserRepositoryAdapter(
+class UserAdapter(
     private val userMapper: UserMapper,
     private val userJpaRepository: UserJpaRepository
 ) : UserRepository {


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 암장에 포함된 난이도 조회 API 추가
``` json
{
    "data": {
        "grades": [
            {
                "gradeId": 1,
                "order": 1,
                "color": {
                    "id": 8,
                    "name": "#A50021",
                    "hex": "테스트 레드"
                }
            },
            {
                "gradeId": 2,
                "order": 2,
                "color": {
                    "id": 9,
                    "name": "#D99058",
                    "hex": "테스트 오렌지"
                }
            },
            {
                "gradeId": 3,
                "order": 3,
                "color": {
                    "id": 10,
                    "name": "#E3A857",
                    "hex": "테스트 옐로우"
                }
            },
            {
                "gradeId": 4,
                "order": 4,
                "color": {
                    "id": 11,
                    "name": "#609078",
                    "hex": "테스트 비리디"
                }
            }
        ]
    }
}
```

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [SPS-167](https://depromeet-16-5.atlassian.net/browse/SPS-167?atlOrigin=eyJpIjoiNjE2ZTA1OGI0MWE0NDA0ODhkYWQzNDEzZjkyMzE4MTEiLCJwIjoiaiJ9)


[SPS-167]: https://depromeet-16-5.atlassian.net/browse/SPS-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ