### PR TITLE
[SPS-175] Exception Handling 상세화 및 AuthenticationEntryPoint 커스터마이징

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/configuration/ClogControllerAdvice.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/configuration/ClogControllerAdvice.kt
@@ -1,11 +1,23 @@
 package org.depromeet.clog.server.api.configuration
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.ConstraintViolationException
+import org.apache.coyote.BadRequestException
 import org.depromeet.clog.server.domain.common.ClogException
+import org.depromeet.clog.server.domain.common.ErrorCode
 import org.depromeet.clog.server.domain.common.ErrorResponse
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.validation.BindException
+import org.springframework.validation.BindingResult
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.multipart.support.MissingServletRequestPartException
 
 @RestControllerAdvice
 class ClogControllerAdvice {
@@ -18,4 +30,63 @@ class ClogControllerAdvice {
         return ResponseEntity.status(e.errorCode.httpStatus)
             .body(ErrorResponse.from(e.errorCode, e.detail))
     }
+
+    @ExceptionHandler(Exception::class)
+    fun handleException(e: Exception): ResponseEntity<ErrorResponse> {
+        logger.error(e) { "Exception 발생: ${e.message}" }
+        val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
+
+        return ResponseEntity.status(errorCode.httpStatus)
+            .body(ErrorResponse.from(errorCode, null))
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(
+        value = [
+            MethodArgumentNotValidException::class,
+            BindException::class,
+            ConstraintViolationException::class,
+            MissingServletRequestParameterException::class,
+            MissingServletRequestPartException::class,
+            IllegalArgumentException::class,
+            HttpMessageNotReadableException::class,
+            BadRequestException::class,
+        ]
+    )
+    fun handleBadRequest(request: HttpServletRequest, e: Exception): ErrorResponse {
+        val reason = buildInvalidRequestReason(e)
+
+        logger.warn(e) { "잘못된 파라미터 입력 발생: $reason, url: ${request.requestURL}" }
+        return ErrorResponse.from(ErrorCode.INVALID_REQUEST, mapOf("reason" to reason))
+    }
+
+    private fun buildInvalidRequestReason(e: Exception): List<String> {
+        return when (e) {
+            is MethodArgumentNotValidException ->
+                e.bindingResult.extractErrorDetail().ifEmpty { buildDefaultMessage(e) }
+
+            is BindException ->
+                e.bindingResult.extractErrorDetail().ifEmpty { buildDefaultMessage(e) }
+
+            is ConstraintViolationException ->
+                e.constraintViolations.map { "${it.propertyPath} -> ${it.message}" }.ifEmpty { buildDefaultMessage(e) }
+
+            is MissingServletRequestParameterException -> listOf("${e.parameterName} 필수 파라미터가 누락되었습니다.")
+
+            is MissingServletRequestPartException -> listOf("${e.requestPartName} 필수 파트가 누락되었습니다.")
+
+            else -> buildDefaultMessage(e)
+        }
+    }
+
+    private fun buildDefaultMessage(e: Exception): List<String> {
+        return if (e.message.isNullOrBlank()) {
+            listOf("잘못된 요청입니다. 자세한 내용은 서버팀에 문의 주세요.")
+        } else {
+            listOf(e.message!!)
+        }
+    }
+
+    private fun BindingResult.extractErrorDetail(): List<String> =
+        this.fieldErrors.map { "${it.field}: ${it.defaultMessage}" }
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/security/ClogAuthenticationEntryPoint.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/security/ClogAuthenticationEntryPoint.kt
@@ -1,0 +1,21 @@
+package org.depromeet.clog.server.api.security
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerExceptionResolver
+
+@Component
+class ClogAuthenticationEntryPoint(
+    private val handlerExceptionResolver: HandlerExceptionResolver,
+) : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        handlerExceptionResolver.resolveException(request, response, null, authException)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/security/SecurityConfig.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/security/SecurityConfig.kt
@@ -11,13 +11,17 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 class SecurityConfig(
-    private val jwtFilter: JwtFilter
+    private val jwtFilter: JwtFilter,
+    private val clogAuthenticationEntryPoint: ClogAuthenticationEntryPoint,
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .exceptionHandling {
+                it.authenticationEntryPoint(clogAuthenticationEntryPoint)
+            }
             .authorizeHttpRequests { auth ->
                 auth.requestMatchers(
                     *PERMIT_ALL_PATTERNS.toTypedArray()

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/common/ErrorCode.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/common/ErrorCode.kt
@@ -6,8 +6,9 @@ enum class ErrorCode(
     val httpStatus: Int
 ) {
 
-    ID_TOKEN_MISSING("C4000", "id_token이 누락되었습니다.", 400),
-    ID_TOKEN_VALIDATION_FAILED("C4001", "id_token 검증에 실패하였습니다.", 400),
+    INVALID_REQUEST("C4000", "잘못된 요청입니다.", 400),
+    ID_TOKEN_MISSING("C4001", "id_token이 누락되었습니다.", 400),
+    ID_TOKEN_VALIDATION_FAILED("C4002", "id_token 검증에 실패하였습니다.", 400),
 
     TOKEN_INVALID("C4010", "토큰이 유효하지 않습니다.", 401),
     TOKEN_EXPIRED("C4011", "토큰이 만료되었습니다.", 401),
@@ -24,4 +25,6 @@ enum class ErrorCode(
     CRAG_NOT_FOUND("C4044", "존재하지 않는 암장입니다.", 404),
     PROBLEM_NOT_FOUND("C4045", "존재하지 않는 문제입니다.", 404),
     GRADE_NOT_FOUND("C4046", "존재하지 않는 난이도입니다.", 404),
+
+    INTERNAL_SERVER_ERROR("C5000", "서버 내부 오류입니다.", 500),
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/common/ErrorResponse.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/common/ErrorResponse.kt
@@ -4,11 +4,11 @@ data class ErrorResponse(
     val name: String,
     val code: String,
     val message: String? = null,
-    val detail: Map<String, Any>? = null
+    val detail: Map<String, Any?>? = null
 ) {
 
     companion object {
-        fun from(errorCode: ErrorCode, detail: Map<String, Any>? = null): ErrorResponse {
+        fun from(errorCode: ErrorCode, detail: Map<String, Any?>? = null): ErrorResponse {
             return ErrorResponse(
                 name = errorCode.name,
                 code = errorCode.code,


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- `AuthenticationEntryPoint`를 재정의하지 않아, 모든 `Exception`에 대해 `403`이 발생하는 이슈를 수정합니다.
- 모든 `Exception`에 대해, Spring boot default exception body가 아닌 `ClogErrorResponse`가 반환되도록 수정합니다.
- 클라이언트에서 잘못된 입력을 시도했을 때, 상세한 `ErrorResponse`가 반환되도록 수정합니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [[SPS-175](https://depromeet-16-5.atlassian.net/browse/SPS-175)]


[SPS-175]: https://depromeet-16-5.atlassian.net/browse/SPS-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ