### PR TITLE
[SPS-180] liveness/readiness health check 추가

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/ClogApplication.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/ClogApplication.kt
@@ -3,11 +3,13 @@ package org.depromeet.clog.server.api
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.scheduling.annotation.EnableScheduling
+import java.util.TimeZone
 
 @SpringBootApplication(scanBasePackages = ["org.depromeet.clog.server"])
 @EnableScheduling
 class ClogApplication
 
 fun main(args: Array<String>) {
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
     runApplication<ClogApplication>(*args)
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/configuration/ClogControllerAdvice.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/configuration/ClogControllerAdvice.kt
@@ -45,7 +45,7 @@ class ClogControllerAdvice {
     fun handleInsufficientAuthenticationException(
         e: InsufficientAuthenticationException
     ): ResponseEntity<ErrorResponse> {
-        logger.error(e) { "InsufficientAuthenticationException 발생: ${e.message}" }
+        logger.error { "InsufficientAuthenticationException 발생: ${e.message}" }
         val errorCode = ErrorCode.TOKEN_INVALID
 
         return ResponseEntity.status(errorCode.httpStatus)

--- a/clog-api/src/main/resources/application.yml
+++ b/clog-api/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  shutdown: graceful
+
 spring:
   servlet:
     multipart:
@@ -60,3 +63,14 @@ management:
     web:
       exposure:
         include: "health"
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      status:
+        http-mapping:
+          DOWN: 503
+          OUT_OF_SERVICE: 503
+          UNKNOWN: 200
+          UP: 200
+        order: DOWN, OUT_OF_SERVICE, UP, UNKNOWN


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- k8s Deployment의 liveness / readiness probe를 적용하기 위해 actuator 설정을 변경합니다.
- 서버 타임존 설정을 추가합니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [[SPS-180](https://depromeet-16-5.atlassian.net/browse/SPS-180)]


[SPS-180]: https://depromeet-16-5.atlassian.net/browse/SPS-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ