### PR TITLE
[SPS-178] k8s manifests 레포지토리 연동을 통한 운영 서버 자동 배포 액션 추가

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,0 +1,54 @@
+name: Build and Update Production k8s Manifests
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    environment: prod
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_TAG: ${{ github.run_number }}-${GITHUB_SHA::8}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Build with Gradle (skip tests)
+        run: ./gradlew build -x test
+
+      - name: Build Docker Image
+        run: docker build -f clog-api/Dockerfile -t ${{ secrets.DOCKER_REGISTRY }}/${{ secrets.DOCKER_IMAGE }}:${IMAGE_TAG} .
+
+      - name: Login to Docker Registry
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login ${{ secrets.DOCKER_REGISTRY }} -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Push Docker Image
+        run: docker push ${{ secrets.DOCKER_REGISTRY }}/${{ secrets.DOCKER_IMAGE }}:${{ github.ref_name }}
+
+      - name: Checkout Manifests Repository
+        uses: actions/checkout@v3
+        with:
+          repository: clog-depromeet/clog-server-argocd-manifests
+          token: ${{ secrets.REPOSITORY_ACCESS_TOKEN }}
+          ref: main
+
+      - name: Update Image Tag in Manifests
+        run: |
+          sed -i "s|image: .*$|image: ${{ secrets.DOCKER_REGISTRY }}/${{ secrets.DOCKER_IMAGE }}:${IMAGE_TAG}|" manifests/api-deployment.yaml
+
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.name "supershy-bot"
+          git config --global user.email "supershy-bot@depromeet.org"
+          git add manifests/api-deployment.yaml
+          git commit -m "Update image tag to ${{ secrets.DOCKER_REGISTRY }}/${{ secrets.DOCKER_IMAGE }}:${IMAGE_TAG}"
+          git push


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- main 브랜치 push 시, 운영 서버 업데이트가 수행되도록 세팅합니다.
  1. 기존과 동일하게 gradle build 후 docker image build & push를 수행합니다.
      - 이 때, 이미지 태그는 github run number(고유한 시퀀스) + commit sha 8자리입니다.
  2. [private k8s Manifests 레포지토리](https://github.com/clog-depromeet/clog-server-argocd-manifests)에 이미지 태그를 업데이트 해줍니다.
  3. ArgoCD가 해당 레포지토리의 변경 사항을 감지하고, 자동으로 싱크 및 배포를 수행해줍니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [[SPS-178](https://depromeet-16-5.atlassian.net/browse/SPS-178)]


[SPS-178]: https://depromeet-16-5.atlassian.net/browse/SPS-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ