### PR TITLE
[SPS-217] 최초 가입 시, `user.name`이 null로 세팅되도록 수정

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/auth/application/strategy/AppleAuthProviderHandler.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/auth/application/strategy/AppleAuthProviderHandler.kt
@@ -115,7 +115,6 @@ class AppleAuthProviderHandler(
         } else {
             val newUser = User(
                 loginId = appleUser.id,
-                name = appleUser.name,
                 provider = Provider.APPLE
             )
             userRepository.save(newUser)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/auth/application/strategy/KakaoAuthProviderHandler.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/auth/application/strategy/KakaoAuthProviderHandler.kt
@@ -80,7 +80,6 @@ class KakaoAuthProviderHandler(
         } else {
             val newUser = User(
                 loginId = kakaoUserInfo.id,
-                name = kakaoUserInfo.nickname,
                 provider = Provider.KAKAO
             )
             userRepository.save(newUser)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/auth/application/strategy/LocalAuthProviderHandler.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/auth/application/strategy/LocalAuthProviderHandler.kt
@@ -34,7 +34,6 @@ class LocalAuthProviderHandler(
         } else {
             val newUser = User(
                 loginId = loginId,
-                name = "로컬_$loginId",
                 provider = Provider.LOCAL
             )
             userRepository.save(newUser)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/report/application/GetReport.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/report/application/GetReport.kt
@@ -90,9 +90,10 @@ class GetReport(
         return reportRepository.getReport(userId, threeMonthsAgo)
     }
 
-    private fun getUserName(userId: Long): String {
-        return userRepository.findByIdAndIsDeletedFalse(userId)
-            ?.name
+    private fun getUserName(userId: Long): String? {
+        val user = userRepository.findByIdAndIsDeletedFalse(userId)
             ?: throw UserNotFoundException()
+
+        return user.name
     }
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/report/presentation/dto/ReportResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/report/presentation/dto/ReportResponse.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "사용자 리포트 응답 DTO")
 data class ReportResponse(
     @Schema(description = "사용자 닉네임", example = "김클로그")
-    val userName: String,
+    val userName: String? = null,
 
     @Schema(description = "최근 3개월 내 시도 횟수", example = "10")
     val recentAttemptCount: Long,

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/presentation/UserResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/user/presentation/UserResponse.kt
@@ -4,9 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "유저 기본 조회 정보")
 data class UserResponse(
-    @Schema(description = "유저 ID")
+    @Schema(description = "유저 ID", example = "1")
     val id: Long,
 
-    @Schema(description = "유저 이름")
-    val name: String,
+    @Schema(description = "유저 이름", example = "권기준")
+    val name: String? = null,
 )

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/user/domain/User.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/user/domain/User.kt
@@ -3,7 +3,7 @@ package org.depromeet.clog.server.domain.user.domain
 data class User(
     val id: Long? = null,
     val loginId: String,
-    var name: String,
+    var name: String? = null,
     val provider: Provider,
     var isDeleted: Boolean = false
 )

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/user/UserEntity.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/user/UserEntity.kt
@@ -14,7 +14,7 @@ class UserEntity(
     @Column(nullable = false, unique = true)
     val loginId: String,
 
-    val name: String,
+    val name: String? = null,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 최초 가입 시, `user.name`을 `null`로 세팅합니다.
  - `users/me` 조회 시, `name`이 `null`이면 클라이언트에서 닉네임 설정 플로우를 전개합니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [[SPS-217](https://depromeet-16-5.atlassian.net/browse/SPS-217)]


[SPS-217]: https://depromeet-16-5.atlassian.net/browse/SPS-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ