### PR TITLE
refactor: 캘린더 조회 시, 기록 별 썸네일 추가

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/calendar/application/CalendarResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/calendar/application/CalendarResponse.kt
@@ -113,6 +113,12 @@ data class CalendarResponse(
         val cragName: String?,
 
         @Schema(
+            description = "해당 기록의 대표 썸네일 URL",
+            example = "https://example.com/thumbnail.jpg",
+        )
+        val thumbnailUrl: String?,
+
+        @Schema(
             description = "해당 스토리의 문제 리스트",
         )
         val problems: List<ProblemGradeSummary>,
@@ -122,6 +128,7 @@ data class CalendarResponse(
                 id = story.id,
                 totalDurationMs = story.totalDurationMs,
                 cragName = story.crag?.name,
+                thumbnailUrl = story.randomThumbnailUrl,
                 problems = story.problems.map { ProblemGradeSummary.from(it) }
             )
         }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/story/StoryQuery.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/story/StoryQuery.kt
@@ -18,10 +18,12 @@ data class StoryQuery(
 
     val attempts: List<AttemptQuery>
         get() = problems.flatMap { it.attempts }
+
+    val randomThumbnailUrl: String?
+        get() = attempts.map { it.video.thumbnailUrl }.randomOrNull()
 }
 
 fun List<StoryQuery>.getRandomThumbnailUrl(): String? {
-    return this.flatMap { it.attempts }
-        .map { it.video.thumbnailUrl }
+    return this.map { it.randomThumbnailUrl }
         .randomOrNull()
 }


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 그렇습니다.. 사실 기록 별로도 썸네일이 필요했었는데, 까먹었습니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

-
