### PR TITLE
fix: 애플 계정 회원 탈퇴 시, authorization_code가 아닌 refresh_token을 전달하도록 수정

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/auth/application/strategy/AppleAuthProviderHandler.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/auth/application/strategy/AppleAuthProviderHandler.kt
@@ -55,7 +55,7 @@ class AppleAuthProviderHandler(
         return tokenService.generateTokens(user)
     }
 
-    private fun requestAppleAccessToken(
+    fun requestAppleAccessToken(
         authorizationCode: String,
         codeVerifier: String
     ): Map<String, Any> {


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 애플 revoke 요청 시, `authorization_code`가 아닌 `refresh_token`을 넘기도록 (급하게) 수정합니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

-
