### PR TITLE
feat: `APP_VERSION` 헤더에 따라 story status 다르게 저장

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/configuration/ApiConstants.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/configuration/ApiConstants.kt
@@ -5,4 +5,6 @@ object ApiConstants {
     private const val API_BASE_PATH_PREFIX = "/api"
 
     const val API_BASE_PATH_V1 = "$API_BASE_PATH_PREFIX/v1"
+
+    const val APP_VERSION_HEADER = "APP_VERSION"
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/application/SaveStory.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/application/SaveStory.kt
@@ -23,9 +23,10 @@ class SaveStory(
     operator fun invoke(
         userId: Long,
         request: SaveStoryRequest,
+        appVersion: String?,
     ): SaveStoryResponse {
         val story = storyRepository.save(
-            request.toDomain(userId)
+            request.toDomain(userId, appVersion)
         )
 
         val problem = problemRepository.save(

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveStoryRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveStoryRequest.kt
@@ -22,13 +22,19 @@ data class SaveStoryRequest(
     val memo: String? = null,
 ) {
 
-    fun toDomain(userId: Long): StoryCommand {
+    fun toDomain(userId: Long, appVersion: String?): StoryCommand {
+        val status = if (appVersion != null && appVersion in setOf("1.0.0", "1.0.1", "1.0.2")) {
+            StoryStatus.DONE
+        } else {
+            StoryStatus.IN_PROGRESS
+        }
+
         return StoryCommand(
             userId = userId,
             cragId = cragId,
             date = LocalDate.now(),
             memo = memo,
-            status = StoryStatus.IN_PROGRESS,
+            status = status,
         )
     }
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/StoryCommandController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/StoryCommandController.kt
@@ -3,6 +3,7 @@ package org.depromeet.clog.server.api.story.presentation
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.api.configuration.ApiConstants.APP_VERSION_HEADER
 import org.depromeet.clog.server.api.configuration.annotation.ApiErrorCodes
 import org.depromeet.clog.server.api.story.application.DeleteStory
 import org.depromeet.clog.server.api.story.application.SaveStory
@@ -31,9 +32,10 @@ class StoryCommandController(
     @PostMapping
     fun save(
         userContext: UserContext,
+        @RequestHeader(APP_VERSION_HEADER, required = false) appVersion: String? = null,
         @RequestBody request: SaveStoryRequest,
     ): ClogApiResponse<SaveStoryResponse> {
-        val result = saveStory(userContext.userId, request)
+        val result = saveStory(userContext.userId, request, appVersion)
         return ClogApiResponse.from(result)
     }
 


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 앱 버전 1.0.2 이하에서는 StoryStatus에 대한 대응을 할 수 없습니다.
  - 따라서, 무조건 DONE으로 저장합니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

-
