### PR TITLE
[SPS-279] 썸네일 이미지 1:1 비율로 자르는 기능 임시 추가

### DIFF
--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/ImageCropper.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/ImageCropper.kt
@@ -1,0 +1,26 @@
+package org.depromeet.clog.server.infrastructure.thumbnail
+
+import org.springframework.web.multipart.MultipartFile
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+object ImageCropper {
+
+    fun cropPngImage(file: MultipartFile): ByteArray {
+        val originalImage = ImageIO.read(file.inputStream)
+            ?: throw IllegalArgumentException("이미지를 읽을 수 없습니다.")
+
+        val width = originalImage.width
+        val height = originalImage.height
+
+        val squareSize = minOf(width, height)
+        val x = (width - squareSize) / 2
+        val y = (height - squareSize) / 2
+
+        val croppedImage = originalImage.getSubimage(x, y, squareSize, squareSize)
+
+        val baos = ByteArrayOutputStream()
+        ImageIO.write(croppedImage, "png", baos)
+        return baos.toByteArray()
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/NcpObjectStorageClient.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/NcpObjectStorageClient.kt
@@ -10,6 +10,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
+import java.io.ByteArrayInputStream
 import java.util.*
 
 @Component
@@ -18,7 +19,8 @@ class NcpObjectStorageClient(
     @Value("\${ncp.storage.region}") private val region: String,
     @Value("\${ncp.storage.access-key}") private val accessKey: String,
     @Value("\${ncp.storage.secret-key}") private val secretKey: String,
-    @Value("\${ncp.storage.end-point}") private val endpoint: String
+    @Value("\${ncp.storage.end-point}") private val endpoint: String,
+    @Value("\${thumbnail.image.crop.enable}") private val isCropEnable: Boolean,
 ) {
 
     private val s3Client: AmazonS3 = run {
@@ -32,13 +34,24 @@ class NcpObjectStorageClient(
 
     fun uploadFile(file: MultipartFile): String {
         val fileName = generateUniqueFileName(file.originalFilename)
-        val metadata = ObjectMetadata().apply {
-            contentLength = file.size
-            contentType = file.contentType
-        }
-        s3Client.putObject(bucketName, fileName, file.inputStream, metadata)
-        s3Client.setObjectAcl(bucketName, fileName, CannedAccessControlList.PublicRead) // ✅ 추가됨
 
+        if (isCropEnable && file.contentType?.equals("image/png", ignoreCase = true) == true) {
+            val croppedBytes = ImageCropper.cropPngImage(file)
+            val croppedInputStream = ByteArrayInputStream(croppedBytes)
+            val metadata = ObjectMetadata().apply {
+                contentLength = croppedBytes.size.toLong()
+                contentType = "image/png"
+            }
+            s3Client.putObject(bucketName, fileName, croppedInputStream, metadata)
+            s3Client.setObjectAcl(bucketName, fileName, CannedAccessControlList.PublicRead)
+        } else {
+            val metadata = ObjectMetadata().apply {
+                contentLength = file.size
+                contentType = file.contentType
+            }
+            s3Client.putObject(bucketName, fileName, file.inputStream, metadata)
+            s3Client.setObjectAcl(bucketName, fileName, CannedAccessControlList.PublicRead)
+        }
         return s3Client.getUrl(bucketName, fileName).toString()
     }
 

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/NcpObjectStorageClient.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/NcpObjectStorageClient.kt
@@ -20,7 +20,7 @@ class NcpObjectStorageClient(
     @Value("\${ncp.storage.access-key}") private val accessKey: String,
     @Value("\${ncp.storage.secret-key}") private val secretKey: String,
     @Value("\${ncp.storage.end-point}") private val endpoint: String,
-    @Value("\${thumbnail.image.crop.enable}") private val isCropEnable: Boolean,
+    @Value("\${thumbnail.crop.enabled}") private val isCropEnabled: Boolean,
 ) {
 
     private val s3Client: AmazonS3 = run {
@@ -35,7 +35,7 @@ class NcpObjectStorageClient(
     fun uploadFile(file: MultipartFile): String {
         val fileName = generateUniqueFileName(file.originalFilename)
 
-        if (isCropEnable && file.contentType?.equals("image/png", ignoreCase = true) == true) {
+        if (isCropEnabled && file.contentType?.equals("image/png", ignoreCase = true) == true) {
             val croppedBytes = ImageCropper.cropPngImage(file)
             val croppedInputStream = ByteArrayInputStream(croppedBytes)
             val metadata = ObjectMetadata().apply {

--- a/clog-infrastructure/src/main/resources/infrastructure/application.yml
+++ b/clog-infrastructure/src/main/resources/infrastructure/application.yml
@@ -30,6 +30,5 @@ kakao:
     local-search-base-url: ${KAKAO_MAP_LOCAL_SEARCH_BASE_URL}
 
 thumbnail:
-  image:
-    crop:
-      enable: true
+  crop:
+    enabled: true

--- a/clog-infrastructure/src/main/resources/infrastructure/application.yml
+++ b/clog-infrastructure/src/main/resources/infrastructure/application.yml
@@ -28,3 +28,8 @@ kakao:
   map:
     rest-api-key: ${KAKAO_MAP_REST_API_KEY}
     local-search-base-url: ${KAKAO_MAP_LOCAL_SEARCH_BASE_URL}
+
+thumbnail:
+  image:
+    crop:
+      enable: true


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 썸네일이 png 타입인 경우, 이미지를 1:1 비율로 자릅니다.
  - 지금 썸네일이 찌부된 상태로 나와, 앱 완성도가 낮아보이기 때문에 조치해둡니다.
- 다만, 이미지를 메모리에 적재한 후 수행하기 때문에 리소스 사용량이 많이 늘어날 수 있습니다.
  - 클라리언트에서 찌부 현상 해결해주면, 바로 없애야 합니다..!

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [[SPS-279](https://depromeet-16-5.atlassian.net/browse/SPS-279)]


[SPS-279]: https://depromeet-16-5.atlassian.net/browse/SPS-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ