### PR TITLE
refactor : 썸네일 업로드 최적화

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/thumbnail/presentation/ThumbnailController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/thumbnail/presentation/ThumbnailController.kt
@@ -5,20 +5,21 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.depromeet.clog.server.api.configuration.ApiConstants.API_BASE_PATH_V1
 import org.depromeet.clog.server.domain.common.ClogApiResponse
+import org.depromeet.clog.server.domain.thumbnail.application.ThumbnailPresignedService
 import org.depromeet.clog.server.domain.thumbnail.application.ThumbnailService
 import org.depromeet.clog.server.domain.thumbnail.application.ThumbnailUploadResponse
+import org.depromeet.clog.server.domain.thumbnail.dto.ThumbnailPresignedUploadRequest
+import org.depromeet.clog.server.domain.thumbnail.dto.ThumbnailPresignedUploadResponse
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestPart
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
 @Tag(name = "썸네일 API", description = "썸네일 관련 작업을 수행합니다.")
 @RestController
 @RequestMapping("$API_BASE_PATH_V1/thumbnails")
 class ThumbnailController(
-    private val thumbnailService: ThumbnailService
+    private val thumbnailService: ThumbnailService,
+    private val thumbnailPresignedService: ThumbnailPresignedService
 ) {
 
     @Operation(summary = "썸네일 업로드")
@@ -29,6 +30,15 @@ class ThumbnailController(
         file: MultipartFile
     ): ClogApiResponse<ThumbnailUploadResponse> {
         val response = thumbnailService.uploadImage(file)
+        return ClogApiResponse.from(response)
+    }
+
+    @Operation(summary = "썸네일 presigned URL 발급")
+    @PostMapping("/upload-url")
+    fun getPresignedUrl(
+        @RequestBody request: ThumbnailPresignedUploadRequest
+    ): ClogApiResponse<ThumbnailPresignedUploadResponse> {
+        val response = thumbnailPresignedService.generatePresignedUrl(request)
         return ClogApiResponse.from(response)
     }
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/thumbnail/application/ThumbnailPresignedService.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/thumbnail/application/ThumbnailPresignedService.kt
@@ -1,0 +1,8 @@
+package org.depromeet.clog.server.domain.thumbnail.application
+
+import org.depromeet.clog.server.domain.thumbnail.dto.ThumbnailPresignedUploadRequest
+import org.depromeet.clog.server.domain.thumbnail.dto.ThumbnailPresignedUploadResponse
+
+interface ThumbnailPresignedService {
+    fun generatePresignedUrl(request: ThumbnailPresignedUploadRequest): ThumbnailPresignedUploadResponse
+}

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/thumbnail/dto/ThumbnailPresignedUploadRequest.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/thumbnail/dto/ThumbnailPresignedUploadRequest.kt
@@ -1,0 +1,6 @@
+package org.depromeet.clog.server.domain.thumbnail.dto
+
+data class ThumbnailPresignedUploadRequest(
+    val originalFilename: String,
+    val contentType: String
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/thumbnail/dto/ThumbnailPresignedUploadResponse.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/thumbnail/dto/ThumbnailPresignedUploadResponse.kt
@@ -1,0 +1,6 @@
+package org.depromeet.clog.server.domain.thumbnail.dto
+
+data class ThumbnailPresignedUploadResponse(
+    val presignedUrl: String,
+    val fileUrl: String
+)

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/ncp/NcpObjectStorageClient.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/ncp/NcpObjectStorageClient.kt
@@ -1,4 +1,4 @@
-package org.depromeet.clog.server.infrastructure.thumbnail
+package org.depromeet.clog.server.infrastructure.thumbnail.ncp
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicAWSCredentials
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.CannedAccessControlList
 import com.amazonaws.services.s3.model.ObjectMetadata
+import org.depromeet.clog.server.infrastructure.thumbnail.ImageCropper
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/ncp/ThumbnailServiceImpl.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/ncp/ThumbnailServiceImpl.kt
@@ -1,4 +1,4 @@
-package org.depromeet.clog.server.infrastructure.thumbnail
+package org.depromeet.clog.server.infrastructure.thumbnail.ncp
 
 import org.depromeet.clog.server.domain.thumbnail.Thumbnail
 import org.depromeet.clog.server.domain.thumbnail.ThumbnailRepository

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/s3/AwsS3PresignedClient.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/s3/AwsS3PresignedClient.kt
@@ -1,0 +1,40 @@
+package org.depromeet.clog.server.infrastructure.thumbnail.s3
+
+import com.amazonaws.HttpMethod
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class AwsS3PresignedClient(
+    @Value("\${aws.s3.bucket-name}") private val bucketName: String,
+    @Value("\${aws.s3.region}") private val region: String,
+    @Value("\${aws.s3.access-key}") private val accessKey: String,
+    @Value("\${aws.s3.secret-key}") private val secretKey: String,
+    @Value("\${aws.cloudfront.domain}") private val cloudFrontDomain: String,
+) {
+
+    private val s3Client: AmazonS3 = AmazonS3ClientBuilder.standard()
+        .withRegion(region)
+        .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials(accessKey, secretKey)))
+        .build()
+
+    fun generatePresignedPutUrl(objectKey: String, contentType: String): String {
+        val expiration = Date(System.currentTimeMillis() + 1000 * 60 * 10)
+        val request = GeneratePresignedUrlRequest(bucketName, objectKey)
+            .withMethod(HttpMethod.PUT)
+            .withExpiration(expiration)
+            .withContentType(contentType)
+
+        return s3Client.generatePresignedUrl(request).toString()
+    }
+
+    fun getCloudFrontUrl(objectKey: String): String {
+        return "https://$cloudFrontDomain/$objectKey"
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/s3/ThumbnailPresignedServiceImpl.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/s3/ThumbnailPresignedServiceImpl.kt
@@ -1,0 +1,27 @@
+package org.depromeet.clog.server.infrastructure.thumbnail.s3
+
+import org.depromeet.clog.server.domain.thumbnail.Thumbnail
+import org.depromeet.clog.server.domain.thumbnail.ThumbnailRepository
+import org.depromeet.clog.server.domain.thumbnail.application.*
+import org.depromeet.clog.server.domain.thumbnail.dto.ThumbnailPresignedUploadRequest
+import org.depromeet.clog.server.domain.thumbnail.dto.ThumbnailPresignedUploadResponse
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class ThumbnailPresignedServiceImpl(
+    private val awsS3PresignedClient: AwsS3PresignedClient,
+    private val thumbnailRepository: ThumbnailRepository
+) : ThumbnailPresignedService {
+
+    override fun generatePresignedUrl(request: ThumbnailPresignedUploadRequest): ThumbnailPresignedUploadResponse {
+        val key = "${UUID.randomUUID()}-${request.originalFilename}"
+        val presignedUrl = awsS3PresignedClient.generatePresignedPutUrl(key, request.contentType)
+        val fileUrl = awsS3PresignedClient.getCloudFrontUrl(key)
+
+        val thumbnail = Thumbnail(fileUrl = fileUrl)
+        thumbnailRepository.save(thumbnail)
+
+        return ThumbnailPresignedUploadResponse(presignedUrl = presignedUrl, fileUrl = fileUrl)
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/s3/ThumbnailPresignedServiceImpl.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/thumbnail/s3/ThumbnailPresignedServiceImpl.kt
@@ -2,11 +2,10 @@ package org.depromeet.clog.server.infrastructure.thumbnail.s3
 
 import org.depromeet.clog.server.domain.thumbnail.Thumbnail
 import org.depromeet.clog.server.domain.thumbnail.ThumbnailRepository
-import org.depromeet.clog.server.domain.thumbnail.application.*
+import org.depromeet.clog.server.domain.thumbnail.application.ThumbnailPresignedService
 import org.depromeet.clog.server.domain.thumbnail.dto.ThumbnailPresignedUploadRequest
 import org.depromeet.clog.server.domain.thumbnail.dto.ThumbnailPresignedUploadResponse
 import org.springframework.stereotype.Service
-import java.util.*
 
 @Service
 class ThumbnailPresignedServiceImpl(
@@ -15,7 +14,7 @@ class ThumbnailPresignedServiceImpl(
 ) : ThumbnailPresignedService {
 
     override fun generatePresignedUrl(request: ThumbnailPresignedUploadRequest): ThumbnailPresignedUploadResponse {
-        val key = "${UUID.randomUUID()}-${request.originalFilename}"
+        val key = request.originalFilename
         val presignedUrl = awsS3PresignedClient.generatePresignedPutUrl(key, request.contentType)
         val fileUrl = awsS3PresignedClient.getCloudFrontUrl(key)
 

--- a/clog-infrastructure/src/main/resources/infrastructure/application.yml
+++ b/clog-infrastructure/src/main/resources/infrastructure/application.yml
@@ -32,3 +32,12 @@ kakao:
 thumbnail:
   crop:
     enabled: true
+
+aws:
+  s3:
+    access-key: ${AWS_S3_ACCESS_KEY}
+    secret-key: ${AWS_S3_SECRET_KEY}
+    region: ap-northeast-2
+    bucket-name: ${AWS_S3_BUCKET_NAME}
+  cloudfront:
+    domain: ${AWS_CLOUDFRONT_DOMAIN}


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항

- 썸네일 업로드가 너무 느려 최적화하였습니다.
- **서버를 거치지 않고 클라이언트에서 직접 S3에 이미지 업로드**를 하는 구조고, **CloudFront로 빠른 이미지 제공**, 그리고 **서버는 presigned URL 발급만 담당**하는 방식으로 변경되었습니다.
- 클라이언트 측에서 S3측으로 이미지 업로드를 수행해야해서 별도 안내 필요합니다.(노션으로 공유 예정) 


