### PR TITLE
[SPS-299] 특정 attempt 삭제 안되는 이슈 수정

### DIFF
--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/story/StoryAdapter.kt
@@ -43,18 +43,26 @@ class StoryAdapter(
 
     override fun findByAttemptId(attemptId: Long): StoryQuery? {
         val entity = storyJpaRepository.findAll {
+            val subquery = select<Long>(
+                path(StoryEntity::id)
+            ).from(
+                entity(StoryEntity::class),
+                join(StoryEntity::problems),
+                join(ProblemEntity::attempts)
+            ).where(
+                path(AttemptEntity::id).eq(attemptId)
+            ).asSubquery()
+
             select(
                 entity(StoryEntity::class)
             ).from(
                 entity(StoryEntity::class),
                 fetchJoin(StoryEntity::problems),
-                join(ProblemEntity::attempts),
+                fetchJoin(ProblemEntity::attempts)
             ).where(
-                path(AttemptEntity::id).eq(attemptId),
+                subquery.eq(path(StoryEntity::id)),
             )
-        }
-            .filterNotNull()
-            .firstOrNull()
+        }.filterNotNull().firstOrNull()
 
         return entity?.let { storyMapper.toDomain(it) }
     }


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 서브쿼리 쓰기 싫은데.. 우선 이렇게 픽스합니다.
- `attempt_id` 기반으로 `story`를 조회할 때, where 조건을 `attempt_id`로 지정하면 해당 attempt와 problem에 대항하는 row만 가져옵니다..
  - 저희가 원하는 동작은 해당 `attempt`가 속하는 `story`의 `problem`과 `attempt`를 모두 가져오는 것이므로, `story_id`를 먼저 구하고 where 조건을 `story_id`에 걸어두는 것으로 수정합니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- [SPS-299](https://depromeet-16-5.atlassian.net/browse/SPS-299)


[SPS-299]: https://depromeet-16-5.atlassian.net/browse/SPS-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ