### PR TITLE
refactor: 캘린더 조회 쿼리 개선

### DIFF
--- a/clog-infrastructure/src/main/resources/infrastructure/application.yml
+++ b/clog-infrastructure/src/main/resources/infrastructure/application.yml
@@ -10,6 +10,8 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate.default_batch_fetch_size: 1000
 
 decorator:
   datasource:


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- `hibernate.default_batch_fetch_size`를 적용하여, in절을 사용해 자식들을 가져오도록 세팅합니다.
- `problems` 정도는 fetch join 하도록 수정합니다.

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

-
