### PR TITLE
refactor: 내 주변 암장 조회 쿼리 내 fetchJoin 제거

### DIFF
--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/CragAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/CragAdapter.kt
@@ -57,7 +57,6 @@ class CragAdapter(
                 entity(CragEntity::class),
             ).from(
                 entity(CragEntity::class),
-                leftFetchJoin(CragEntity::grades)
             ).where(
                 and(
                     cursor?.let {


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

```
firstResult/maxResults specified with collection fetch; applying in memory
```
- 굉장히 익숙한 warn 로그가..
- `hibernate.default_batch_fetch_size`가 in절로 조회 때려줄테니.. fetch join을 그냥 빼버립시당

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

-
