### PR TITLE
fix: MySQL 9.2.0 에서 DISTINCT + ORDER BY 오류 발생 문제 해결

### DIFF
--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/ColorJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/crag/ColorJpaRepository.kt
@@ -20,7 +20,8 @@ interface ColorJpaRepository : JpaRepository<ColorEntity, Long> {
         JOIN g.color c
         WHERE s.userId = :userId
           AND (:cursor IS NULL OR c.id < :cursor)
-        ORDER BY g.id DESC
+        GROUP BY c.id
+        ORDER BY MAX(g.id) DESC
         """
     )
     fun findDistinctColorsByUserIdWithCursor(


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->
- 문제 정의 : dev 환경에서 /crags/me 에러
- 원인 : DISTINCT와 ORDER BY(g.id)가 함께 사용되면서 MySQL 8.0 이상에서 "Expression not in SELECT list" 오류가 발생.(dev는 MySQL 9.2.0)
- 해결 : GROUP BY + ORDER BY MAX(...)로 구조 변경하여 호환성 확보.

