### PR TITLE
feat : 갤러리 영상 묶음 기록 등록 api 구현

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/application/SaveGalleryStory.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/application/SaveGalleryStory.kt
@@ -1,0 +1,69 @@
+package org.depromeet.clog.server.api.story.application
+
+import org.depromeet.clog.server.api.story.presentation.SaveGalleryStoryRequest
+import org.depromeet.clog.server.api.story.presentation.SaveGalleryStoryResponse
+import org.depromeet.clog.server.domain.attempt.AttemptCommand
+import org.depromeet.clog.server.domain.attempt.AttemptRepository
+import org.depromeet.clog.server.domain.attempt.AttemptStatus
+import org.depromeet.clog.server.domain.problem.ProblemCommand
+import org.depromeet.clog.server.domain.problem.ProblemRepository
+import org.depromeet.clog.server.domain.story.StoryCommand
+import org.depromeet.clog.server.domain.story.StoryRepository
+import org.depromeet.clog.server.domain.story.StoryStatus
+import org.depromeet.clog.server.domain.video.VideoCommand
+import org.depromeet.clog.server.domain.video.VideoRepository
+import org.depromeet.clog.server.domain.video.VideoStampRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class SaveGalleryStory(
+    private val storyRepository: StoryRepository,
+    private val problemRepository: ProblemRepository,
+    private val attemptRepository: AttemptRepository,
+    private val videoRepository: VideoRepository,
+    private val videoStampRepository: VideoStampRepository
+) {
+    operator fun invoke(userId: Long, request: SaveGalleryStoryRequest): SaveGalleryStoryResponse {
+        val story = storyRepository.save(
+            StoryCommand(
+                userId = userId,
+                cragId = request.cragId,
+                date = request.date,
+                memo = request.memo,
+                status = StoryStatus.IN_PROGRESS
+            )
+        )
+
+        val problem = problemRepository.save(
+            ProblemCommand(
+                storyId = story.id,
+                gradeId = null
+            )
+        )
+
+        request.videos.forEach { videoReq ->
+            val video = videoRepository.save(
+                VideoCommand(
+                    durationMs = videoReq.durationMs,
+                    thumbnailUrl = videoReq.thumbnailUrl,
+                    localPath = videoReq.localPath
+                )
+            )
+
+            videoStampRepository.saveAll(
+                videoReq.stamps.map { it.toDomain(video.id) }
+            )
+            attemptRepository.save(
+                AttemptCommand(
+                    problemId = problem.id,
+                    videoId = video.id,
+                    status = AttemptStatus.UNKNOWN
+                )
+            )
+        }
+
+        return SaveGalleryStoryResponse(story.id)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/GalleryStoryCommandController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/GalleryStoryCommandController.kt
@@ -1,0 +1,32 @@
+package org.depromeet.clog.server.api.story.presentation
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.api.story.application.SaveGalleryStory
+import org.depromeet.clog.server.api.user.UserContext
+import org.depromeet.clog.server.domain.common.ClogApiResponse
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "기록 API", description = "갤러리 영상 묶음 기록 등록 API")
+@RequestMapping("${ApiConstants.API_BASE_PATH_V1}/stories")
+@RestController
+class GalleryStoryCommandController(
+    private val saveGalleryStory: SaveGalleryStory
+) {
+    @Operation(
+        summary = "갤러리에서 여러 영상을 묶어 기록 저장",
+        description = "암장 이름, 날짜, 메모와 함께 여러 개의 영상을 기록으로 묶어 저장합니다. 저장된 기록은 폴더/캘린더에 반영됩니다."
+    )
+    @PostMapping("/gallery")
+    fun register(
+        userContext: UserContext,
+        @RequestBody request: SaveGalleryStoryRequest
+    ): ClogApiResponse<SaveGalleryStoryResponse> {
+        val result = saveGalleryStory(userContext.userId, request)
+        return ClogApiResponse.from(result)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveGalleryStoryRequest.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveGalleryStoryRequest.kt
@@ -1,0 +1,20 @@
+package org.depromeet.clog.server.api.story.presentation
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.depromeet.clog.server.api.attempt.presentation.dto.SaveVideoRequest
+import java.time.LocalDate
+
+@Schema(description = "갤러리 영상 묶음 기록 요청")
+data class SaveGalleryStoryRequest(
+    @Schema(description = "기록 날짜", example = "2024-05-25")
+    val date: LocalDate,
+
+    @Schema(description = "암장 ID", example = "1")
+    val cragId: Long,
+
+    @Schema(description = "기록 메모", example = "오늘 죽을 뻔함")
+    val memo: String? = null,
+
+    @Schema(description = "등록할 영상 목록")
+    val videos: List<SaveVideoRequest>
+)

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveGalleryStoryResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/presentation/SaveGalleryStoryResponse.kt
@@ -1,0 +1,9 @@
+package org.depromeet.clog.server.api.story.presentation
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "갤러리 영상 묶음 기록 저장 응답")
+data class SaveGalleryStoryResponse(
+    @Schema(description = "기록 ID", example = "1")
+    val storyId: Long
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/AttemptStatus.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/attempt/AttemptStatus.kt
@@ -2,5 +2,6 @@ package org.depromeet.clog.server.domain.attempt
 
 enum class AttemptStatus {
     SUCCESS,
-    FAILURE
+    FAILURE,
+    UNKNOWN
 }

--- a/clog-infrastructure/src/main/resources/infrastructure/db/migration/V8__alter_attempt_status_default.sql
+++ b/clog-infrastructure/src/main/resources/infrastructure/db/migration/V8__alter_attempt_status_default.sql
@@ -1,0 +1,8 @@
+-- 1. 기존 NULL 값 처리: UNKNOWN으로 치환
+UPDATE attempt
+SET status = 'UNKNOWN'
+WHERE status IS NULL;
+
+-- 2. DEFAULT 값 설정
+ALTER TABLE attempt
+    ALTER COLUMN status SET DEFAULT 'UNKNOWN';


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항

### POST /api/v1/stories/gallery

1. `Story` 생성
2. `Problem` 연결 및 저장
3. `Video` 개수만큼 `Attempt` 자동 생성 (1:1 연결)
4. 각 `Video` 저장

- 추가 작업:
  - `Attempt.status` 컬럼에 `UNKNOWN` enum 값을 추가했습니다.
  - 갤러리 영상 묶음 기록 등록 시 사용자로부터 `status`(예: 성공/실패) 값을 받지 않으므로,  `UNKNOWN`을 저장합니다.
  - 후속적으로 `attempt.status`는 영상 검토 또는 사용자 입력에 따라 변경될 수 있습니다.
  - 기획에 따라 사용자는 단순 영상 업로드만 수행하고, 시도 결과는 별도로 입력하지 않도록 구현되어 있습니다.
  - 따라서 최초 insert 시에는 `UNKNOWN`으로 통일 저장하고, 등록 후 수정에서 `SUCCESS`, `FAILURE` 등으로 갱신해야합니다.
  - 문제 난이도 또한 등록 후 수정에서 갱신합니다.

-----


