### PR TITLE
fix : "갤러리 영상 묶음 기록 등록 API" 에서 StoryStatus를 DONE으로 바로 저장하도록 변경

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/application/SaveGalleryStory.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/story/application/SaveGalleryStory.kt
@@ -32,7 +32,7 @@ class SaveGalleryStory(
                 cragId = request.cragId,
                 date = request.date,
                 memo = request.memo,
-                status = StoryStatus.IN_PROGRESS
+                status = StoryStatus.DONE
             )
         )
 


### PR DESCRIPTION
## 변경 유형

- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- story 등록하자마자 외부 노출되도록 변경 요청
-> 갤러리 영상 묶음 기록 등록 API" 에서 StoryStatus를 DONE으로 바로 저장하도록 변경


