### PR TITLE
feat : 알림탭 조회/삭제 기능 구현

### DIFF
--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/application/CheckUnreadNotificationExist.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/application/CheckUnreadNotificationExist.kt
@@ -1,0 +1,15 @@
+package org.depromeet.clog.server.api.notification.application
+
+import org.depromeet.clog.server.domain.notification.NotificationRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class CheckUnreadNotificationExist(
+    private val notificationRepository: NotificationRepository
+) {
+    operator fun invoke(userId: Long): Boolean {
+        return notificationRepository.existsUnreadByUserId(userId)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/application/DeleteNotification.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/application/DeleteNotification.kt
@@ -1,0 +1,19 @@
+package org.depromeet.clog.server.api.notification.application
+
+import org.depromeet.clog.server.domain.notification.NotificationNotFoundException
+import org.depromeet.clog.server.domain.notification.NotificationRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class DeleteNotification(
+    private val notificationRepository: NotificationRepository
+) {
+    operator fun invoke(userId: Long, notificationId: Long) {
+        val deletedCount = notificationRepository.deleteByIdAndUserId(notificationId, userId)
+        if (deletedCount == 0) {
+            throw NotificationNotFoundException()
+        }
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/application/GetNotifications.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/application/GetNotifications.kt
@@ -2,6 +2,7 @@ package org.depromeet.clog.server.api.notification.application
 
 import org.depromeet.clog.server.api.notification.presentation.NotificationResponse
 import org.depromeet.clog.server.domain.notification.NotificationRepository
+import org.depromeet.clog.server.domain.notification.NotificationType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -11,12 +12,21 @@ import java.time.LocalDateTime
 class GetNotifications(
     private val notificationRepository: NotificationRepository,
 ) {
-    operator fun invoke(userId: Long, page: Int, size: Int): List<NotificationResponse> {
+    operator fun invoke(
+        userId: Long,
+        page: Int,
+        size: Int,
+        type: NotificationType?
+    ): List<NotificationResponse> {
         val thresholdDate = LocalDateTime.now().minusDays(30)
         notificationRepository.clearNewFlags(userId)
 
-        val notifications =
+        val notifications = if (type != null) {
+            notificationRepository.findByUserIdAndType(userId, type, thresholdDate, page, size)
+        } else {
             notificationRepository.findRecentByUserId(userId, thresholdDate, page, size)
+        }
+
         return notifications.map { NotificationResponse.from(it) }
     }
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/application/GetNotifications.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/application/GetNotifications.kt
@@ -1,0 +1,22 @@
+package org.depromeet.clog.server.api.notification.application
+
+import org.depromeet.clog.server.api.notification.presentation.NotificationResponse
+import org.depromeet.clog.server.domain.notification.NotificationRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+@Transactional
+class GetNotifications(
+    private val notificationRepository: NotificationRepository,
+) {
+    operator fun invoke(userId: Long, page: Int, size: Int): List<NotificationResponse> {
+        val thresholdDate = LocalDateTime.now().minusDays(30)
+        notificationRepository.clearNewFlags(userId)
+
+        val notifications =
+            notificationRepository.findRecentByUserId(userId, thresholdDate, page, size)
+        return notifications.map { NotificationResponse.from(it) }
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/application/MarkNotificationRead.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/application/MarkNotificationRead.kt
@@ -1,0 +1,19 @@
+package org.depromeet.clog.server.api.notification.application
+
+import org.depromeet.clog.server.domain.notification.NotificationNotFoundException
+import org.depromeet.clog.server.domain.notification.NotificationRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class MarkNotificationRead(
+    private val notificationRepository: NotificationRepository
+) {
+    operator fun invoke(userId: Long, notificationId: Long) {
+        val affected = notificationRepository.markAsRead(userId, notificationId)
+        if (affected == 0) {
+            throw NotificationNotFoundException()
+        }
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationCommandController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationCommandController.kt
@@ -1,0 +1,30 @@
+package org.depromeet.clog.server.api.notification.presentation
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.api.notification.application.DeleteNotification
+import org.depromeet.clog.server.api.user.UserContext
+import org.depromeet.clog.server.domain.common.ClogApiResponse
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Notification API", description = "알림 관련 API")
+@RequestMapping("${ApiConstants.API_BASE_PATH_V1}/notifications")
+@RestController
+class NotificationCommandController(
+    private val deleteNotification: DeleteNotification,
+) {
+
+    @Operation(summary = "알림 삭제", description = "특정 알림을 삭제합니다.")
+    @DeleteMapping("/{id}")
+    fun deleteNotification(
+        userContext: UserContext,
+        @PathVariable id: Long,
+    ): ClogApiResponse<Unit> {
+        deleteNotification(userContext.userId, id)
+        return ClogApiResponse.from(Unit)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationCommandController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationCommandController.kt
@@ -4,18 +4,17 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.depromeet.clog.server.api.configuration.ApiConstants
 import org.depromeet.clog.server.api.notification.application.DeleteNotification
+import org.depromeet.clog.server.api.notification.application.MarkNotificationRead
 import org.depromeet.clog.server.api.user.UserContext
 import org.depromeet.clog.server.domain.common.ClogApiResponse
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Tag(name = "Notification API", description = "알림 관련 API")
 @RequestMapping("${ApiConstants.API_BASE_PATH_V1}/notifications")
 @RestController
 class NotificationCommandController(
     private val deleteNotification: DeleteNotification,
+    private val markNotificationAsRead: MarkNotificationRead
 ) {
 
     @Operation(summary = "알림 삭제", description = "특정 알림을 삭제합니다.")
@@ -25,6 +24,19 @@ class NotificationCommandController(
         @PathVariable id: Long,
     ): ClogApiResponse<Unit> {
         deleteNotification(userContext.userId, id)
+        return ClogApiResponse.from(Unit)
+    }
+
+    @Operation(
+        summary = "알림 읽음 처리",
+        description = "알림탭에서 알림 클릭으로 직접 이동 시 호출"
+    )
+    @PatchMapping("/{id}/read")
+    fun markAsRead(
+        userContext: UserContext,
+        @PathVariable id: Long
+    ): ClogApiResponse<Unit> {
+        markNotificationAsRead(userContext.userId, id)
         return ClogApiResponse.from(Unit)
     }
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationQueryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationQueryController.kt
@@ -40,7 +40,7 @@ class NotificationQueryController(
     }
 
     @Operation(
-        summary = "새 알림 존재 여부 조회(알림 아이콘 레드닷에 표시에 사용)",
+        summary = "새 알림 존재 여부 조회(앱 뱃지와 레드닷 표시에 사용)",
         description = "새 알림이 하나라도 있으면 true, 아니면 false 반환"
     )
     @GetMapping("/has-unread")

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationQueryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationQueryController.kt
@@ -1,11 +1,14 @@
 package org.depromeet.clog.server.api.notification.presentation
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.depromeet.clog.server.api.configuration.ApiConstants
 import org.depromeet.clog.server.api.notification.application.GetNotifications
 import org.depromeet.clog.server.api.user.UserContext
 import org.depromeet.clog.server.domain.common.ClogApiResponse
+import org.depromeet.clog.server.domain.notification.NotificationType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -23,9 +26,14 @@ class NotificationQueryController(
     fun getNotifications(
         userContext: UserContext,
         @RequestParam(defaultValue = "0") page: Int,
-        @RequestParam(defaultValue = "10") size: Int
+        @RequestParam(defaultValue = "10") size: Int,
+        @Parameter(
+            description = "알림 타입 필터 (FOLLOW : 친구추가 / EVENT : 이벤트 / null : 전체)",
+            `in` = ParameterIn.QUERY
+        )
+        @RequestParam(required = false) type: NotificationType? = null
     ): ClogApiResponse<List<NotificationResponse>> {
-        val notifications = getNotifications(userContext.userId, page, size)
+        val notifications = getNotifications(userContext.userId, page, size, type)
         return ClogApiResponse.from(notifications)
     }
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationQueryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationQueryController.kt
@@ -1,0 +1,31 @@
+package org.depromeet.clog.server.api.notification.presentation
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.api.notification.application.GetNotifications
+import org.depromeet.clog.server.api.user.UserContext
+import org.depromeet.clog.server.domain.common.ClogApiResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Notification API", description = "알림 조회 API")
+@RequestMapping("${ApiConstants.API_BASE_PATH_V1}/notifications")
+@RestController
+class NotificationQueryController(
+    private val getNotifications: GetNotifications,
+) {
+
+    @Operation(summary = "알림 전체 조회", description = "최근 30일 이내의 알림을 최신순으로 조회.")
+    @GetMapping
+    fun getNotifications(
+        userContext: UserContext,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int
+    ): ClogApiResponse<List<NotificationResponse>> {
+        val notifications = getNotifications(userContext.userId, page, size)
+        return ClogApiResponse.from(notifications)
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationQueryController.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationQueryController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.depromeet.clog.server.api.configuration.ApiConstants
+import org.depromeet.clog.server.api.notification.application.CheckUnreadNotificationExist
 import org.depromeet.clog.server.api.notification.application.GetNotifications
 import org.depromeet.clog.server.api.user.UserContext
 import org.depromeet.clog.server.domain.common.ClogApiResponse
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class NotificationQueryController(
     private val getNotifications: GetNotifications,
+    private val checkUnreadNotificationExist: CheckUnreadNotificationExist
 ) {
 
     @Operation(summary = "알림 전체 조회", description = "최근 30일 이내의 알림을 최신순으로 조회.")
@@ -35,5 +37,17 @@ class NotificationQueryController(
     ): ClogApiResponse<List<NotificationResponse>> {
         val notifications = getNotifications(userContext.userId, page, size, type)
         return ClogApiResponse.from(notifications)
+    }
+
+    @Operation(
+        summary = "새 알림 존재 여부 조회(알림 아이콘 레드닷에 표시에 사용)",
+        description = "새 알림이 하나라도 있으면 true, 아니면 false 반환"
+    )
+    @GetMapping("/has-unread")
+    fun unreadExist(
+        userContext: UserContext
+    ): ClogApiResponse<UnreadExistResponse> {
+        val exists = checkUnreadNotificationExist(userContext.userId)
+        return ClogApiResponse.from(UnreadExistResponse(exists))
     }
 }

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationResponse.kt
@@ -8,6 +8,7 @@ import java.time.LocalDateTime
 data class NotificationResponse(
     @Schema(description = "알림 ID") val id: Long,
     @Schema(description = "알림 타입(FOLLOW / EVENT)") val type: String,
+    @Schema(description = "대상 리디렉션 ID") val targetId: Long,
     @Schema(description = "제목") val title: String,
     @Schema(description = "메시지") val message: String,
     @Schema(description = "읽음 여부") val isRead: Boolean,
@@ -18,6 +19,7 @@ data class NotificationResponse(
             return NotificationResponse(
                 id = notificationQuery.id,
                 type = notificationQuery.type.name,
+                targetId = notificationQuery.targetId,
                 title = notificationQuery.title,
                 message = notificationQuery.message,
                 isRead = notificationQuery.isRead,

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/NotificationResponse.kt
@@ -1,0 +1,28 @@
+package org.depromeet.clog.server.api.notification.presentation
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.depromeet.clog.server.domain.notification.NotificationQuery
+import java.time.LocalDateTime
+
+@Schema(description = "알림 응답")
+data class NotificationResponse(
+    @Schema(description = "알림 ID") val id: Long,
+    @Schema(description = "알림 타입(FOLLOW / EVENT)") val type: String,
+    @Schema(description = "제목") val title: String,
+    @Schema(description = "메시지") val message: String,
+    @Schema(description = "읽음 여부") val isRead: Boolean,
+    @Schema(description = "알림 생성 시각") val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(notificationQuery: NotificationQuery): NotificationResponse {
+            return NotificationResponse(
+                id = notificationQuery.id,
+                type = notificationQuery.type.name,
+                title = notificationQuery.title,
+                message = notificationQuery.message,
+                isRead = notificationQuery.isRead,
+                createdAt = notificationQuery.createdAt
+            )
+        }
+    }
+}

--- a/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/UnreadExistResponse.kt
+++ b/clog-api/src/main/kotlin/org/depromeet/clog/server/api/notification/presentation/UnreadExistResponse.kt
@@ -1,0 +1,9 @@
+package org.depromeet.clog.server.api.notification.presentation
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "알림 레드닷 표시")
+data class UnreadExistResponse(
+    @Schema(description = "true: 새 알림 존재 / false: 새 알림 없음", example = "true")
+    val exists: Boolean
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/common/ErrorCode.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/common/ErrorCode.kt
@@ -25,6 +25,7 @@ enum class ErrorCode(
     CRAG_NOT_FOUND("C4044", "존재하지 않는 암장입니다.", 404),
     PROBLEM_NOT_FOUND("C4045", "존재하지 않는 문제입니다.", 404),
     GRADE_NOT_FOUND("C4046", "존재하지 않는 난이도입니다.", 404),
+    NOTIFICATION_NOT_FOUND("C4047", "존재하지 않는 알림입니다.", 404),
 
     INTERNAL_SERVER_ERROR("C5000", "서버 내부 오류입니다.", 500),
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationCommand.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationCommand.kt
@@ -1,0 +1,9 @@
+package org.depromeet.clog.server.domain.notification
+
+data class NotificationCommand(
+    val userId: Long,
+    val type: NotificationType,
+    val targetId: Long,
+    val title: String,
+    val message: String,
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationNotFoundException.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationNotFoundException.kt
@@ -1,0 +1,11 @@
+package org.depromeet.clog.server.domain.notification
+
+import org.depromeet.clog.server.domain.common.ClogException
+import org.depromeet.clog.server.domain.common.ErrorCode
+
+class NotificationNotFoundException(
+    message: String = "해당 알림을 찾을 수 없습니다.",
+) : ClogException(
+    errorCode = ErrorCode.NOTIFICATION_NOT_FOUND,
+    message = message,
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationQuery.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationQuery.kt
@@ -1,0 +1,16 @@
+package org.depromeet.clog.server.domain.notification
+
+import java.time.LocalDateTime
+
+data class NotificationQuery(
+    val id: Long,
+    val userId: Long,
+    val type: NotificationType,
+    val title: String,
+    val message: String,
+    val targetId: Long,
+    val isRead: Boolean,
+    val readAt: LocalDateTime?,
+    val isNewFlagCleared: Boolean,
+    val createdAt: LocalDateTime,
+)

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationRepository.kt
@@ -10,5 +10,14 @@ interface NotificationRepository {
         size: Int
     ): List<NotificationQuery>
 
+    @Suppress("LongParameterList")
+    fun findByUserIdAndType(
+        userId: Long,
+        type: NotificationType,
+        from: LocalDateTime,
+        page: Int,
+        size: Int
+    ): List<NotificationQuery>
+
     fun clearNewFlags(userId: Long)
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationRepository.kt
@@ -24,4 +24,6 @@ interface NotificationRepository {
     fun deleteByIdAndUserId(notificationId: Long, userId: Long): Int
 
     fun existsUnreadByUserId(userId: Long): Boolean
+
+    fun markAsRead(userId: Long, notificationId: Long): Int
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationRepository.kt
@@ -20,4 +20,6 @@ interface NotificationRepository {
     ): List<NotificationQuery>
 
     fun clearNewFlags(userId: Long)
+
+    fun deleteByIdAndUserId(notificationId: Long, userId: Long): Int
 }

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationRepository.kt
@@ -1,0 +1,14 @@
+package org.depromeet.clog.server.domain.notification
+
+import java.time.LocalDateTime
+
+interface NotificationRepository {
+    fun findRecentByUserId(
+        userId: Long,
+        from: LocalDateTime,
+        page: Int,
+        size: Int
+    ): List<NotificationQuery>
+
+    fun clearNewFlags(userId: Long)
+}

--- a/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationRepository.kt
+++ b/clog-domain/src/main/kotlin/org/depromeet/clog/server/domain/notification/NotificationRepository.kt
@@ -22,4 +22,6 @@ interface NotificationRepository {
     fun clearNewFlags(userId: Long)
 
     fun deleteByIdAndUserId(notificationId: Long, userId: Long): Int
+
+    fun existsUnreadByUserId(userId: Long): Boolean
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/mappers/NotificationMapper.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/mappers/NotificationMapper.kt
@@ -1,0 +1,24 @@
+package org.depromeet.clog.server.infrastructure.mappers
+
+import org.depromeet.clog.server.domain.notification.NotificationQuery
+import org.depromeet.clog.server.infrastructure.notification.NotificationEntity
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationMapper {
+
+    fun toDomain(entity: NotificationEntity): NotificationQuery {
+        return NotificationQuery(
+            id = entity.id!!,
+            userId = entity.receiver.id!!,
+            type = entity.type,
+            title = entity.title,
+            message = entity.message,
+            targetId = entity.targetId,
+            isRead = entity.isRead,
+            readAt = entity.readAt,
+            isNewFlagCleared = entity.isNewFlagCleared,
+            createdAt = entity.createdAt
+        )
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationAdapter.kt
@@ -2,6 +2,7 @@ package org.depromeet.clog.server.infrastructure.notification
 
 import org.depromeet.clog.server.domain.notification.NotificationQuery
 import org.depromeet.clog.server.domain.notification.NotificationRepository
+import org.depromeet.clog.server.domain.notification.NotificationType
 import org.depromeet.clog.server.infrastructure.mappers.NotificationMapper
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
@@ -20,12 +21,33 @@ class NotificationAdapter(
         size: Int
     ): List<NotificationQuery> {
         val pageable = PageRequest.of(page, size)
-        return notificationJpaRepository.findByReceiverIdAndCreatedAtAfterOrderByCreatedAtDesc(
-            userId,
-            from,
-            pageable
-        )
-            .map { notificationMapper.toDomain(it) }
+        return notificationJpaRepository
+            .findByReceiverIdAndCreatedAtAfterOrderByCreatedAtDesc(
+                userId,
+                from,
+                pageable
+            ).map {
+                notificationMapper.toDomain(it)
+            }
+    }
+
+    override fun findByUserIdAndType(
+        userId: Long,
+        type: NotificationType,
+        from: LocalDateTime,
+        page: Int,
+        size: Int
+    ): List<NotificationQuery> {
+        val pageable = PageRequest.of(page, size)
+        return notificationJpaRepository
+            .findByReceiverIdAndTypeAndCreatedAtAfterOrderByCreatedAtDesc(
+                userId,
+                type,
+                from,
+                pageable
+            ).map {
+                notificationMapper.toDomain(it)
+            }
     }
 
     override fun clearNewFlags(userId: Long) {

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationAdapter.kt
@@ -53,4 +53,8 @@ class NotificationAdapter(
     override fun clearNewFlags(userId: Long) {
         notificationJpaRepository.clearNewFlags(userId)
     }
+
+    override fun deleteByIdAndUserId(notificationId: Long, userId: Long): Int {
+        return notificationJpaRepository.deleteByIdAndReceiverId(notificationId, userId)
+    }
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationAdapter.kt
@@ -61,4 +61,8 @@ class NotificationAdapter(
     override fun existsUnreadByUserId(userId: Long): Boolean {
         return notificationJpaRepository.existsByReceiverIdAndIsNewFlagClearedFalse(userId)
     }
+
+    override fun markAsRead(userId: Long, notificationId: Long): Int {
+        return notificationJpaRepository.markAsRead(notificationId, userId)
+    }
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationAdapter.kt
@@ -1,0 +1,34 @@
+package org.depromeet.clog.server.infrastructure.notification
+
+import org.depromeet.clog.server.domain.notification.NotificationQuery
+import org.depromeet.clog.server.domain.notification.NotificationRepository
+import org.depromeet.clog.server.infrastructure.mappers.NotificationMapper
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class NotificationAdapter(
+    private val notificationJpaRepository: NotificationJpaRepository,
+    private val notificationMapper: NotificationMapper
+) : NotificationRepository {
+
+    override fun findRecentByUserId(
+        userId: Long,
+        from: LocalDateTime,
+        page: Int,
+        size: Int
+    ): List<NotificationQuery> {
+        val pageable = PageRequest.of(page, size)
+        return notificationJpaRepository.findByReceiverIdAndCreatedAtAfterOrderByCreatedAtDesc(
+            userId,
+            from,
+            pageable
+        )
+            .map { notificationMapper.toDomain(it) }
+    }
+
+    override fun clearNewFlags(userId: Long) {
+        notificationJpaRepository.clearNewFlags(userId)
+    }
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationAdapter.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationAdapter.kt
@@ -57,4 +57,8 @@ class NotificationAdapter(
     override fun deleteByIdAndUserId(notificationId: Long, userId: Long): Int {
         return notificationJpaRepository.deleteByIdAndReceiverId(notificationId, userId)
     }
+
+    override fun existsUnreadByUserId(userId: Long): Boolean {
+        return notificationJpaRepository.existsByReceiverIdAndIsNewFlagClearedFalse(userId)
+    }
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationJpaRepository.kt
@@ -35,4 +35,6 @@ interface NotificationJpaRepository : JpaRepository<NotificationEntity, Long> {
     @Modifying
     @Query("DELETE FROM NotificationEntity n WHERE n.id = :notificationId AND n.receiver.id = :userId")
     fun deleteByIdAndReceiverId(notificationId: Long, userId: Long): Int
+
+    fun existsByReceiverIdAndIsNewFlagClearedFalse(receiverId: Long): Boolean
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationJpaRepository.kt
@@ -1,5 +1,6 @@
 package org.depromeet.clog.server.infrastructure.notification
 
+import org.depromeet.clog.server.domain.notification.NotificationType
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
@@ -10,6 +11,13 @@ interface NotificationJpaRepository : JpaRepository<NotificationEntity, Long> {
 
     fun findByReceiverIdAndCreatedAtAfterOrderByCreatedAtDesc(
         receiverId: Long,
+        createdAt: LocalDateTime,
+        pageable: Pageable
+    ): List<NotificationEntity>
+
+    fun findByReceiverIdAndTypeAndCreatedAtAfterOrderByCreatedAtDesc(
+        receiverId: Long,
+        type: NotificationType,
         createdAt: LocalDateTime,
         pageable: Pageable
     ): List<NotificationEntity>

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationJpaRepository.kt
@@ -1,0 +1,26 @@
+package org.depromeet.clog.server.infrastructure.notification
+
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
+
+interface NotificationJpaRepository : JpaRepository<NotificationEntity, Long> {
+
+    fun findByReceiverIdAndCreatedAtAfterOrderByCreatedAtDesc(
+        receiverId: Long,
+        createdAt: LocalDateTime,
+        pageable: Pageable
+    ): List<NotificationEntity>
+
+    @Modifying
+    @Query(
+        """
+        UPDATE NotificationEntity n
+        SET n.isNewFlagCleared = true
+        WHERE n.receiver.id = :userId AND n.isNewFlagCleared = false
+        """
+    )
+    fun clearNewFlags(userId: Long)
+}

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationJpaRepository.kt
@@ -31,4 +31,8 @@ interface NotificationJpaRepository : JpaRepository<NotificationEntity, Long> {
         """
     )
     fun clearNewFlags(userId: Long)
+
+    @Modifying
+    @Query("DELETE FROM NotificationEntity n WHERE n.id = :notificationId AND n.receiver.id = :userId")
+    fun deleteByIdAndReceiverId(notificationId: Long, userId: Long): Int
 }

--- a/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationJpaRepository.kt
+++ b/clog-infrastructure/src/main/kotlin/org/depromeet/clog/server/infrastructure/notification/NotificationJpaRepository.kt
@@ -37,4 +37,18 @@ interface NotificationJpaRepository : JpaRepository<NotificationEntity, Long> {
     fun deleteByIdAndReceiverId(notificationId: Long, userId: Long): Int
 
     fun existsByReceiverIdAndIsNewFlagClearedFalse(receiverId: Long): Boolean
+
+    @Modifying
+    @Query(
+        """
+    UPDATE NotificationEntity n
+    SET n.isRead = true,
+        n.readAt = CURRENT_TIMESTAMP,
+        n.isNewFlagCleared = true
+    WHERE n.id = :notificationId
+      AND n.receiver.id = :userId
+      AND (n.isRead = false OR n.isNewFlagCleared = false)
+      """
+    )
+    fun markAsRead(notificationId: Long, userId: Long): Int
 }


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

### GET /notifications
- 최근 30일 이내의 알림을 최신순으로 조회
- 알림 타입 필터로 종류별 알림조회 가능 (FOLLOW : 친구추가 / EVENT : 이벤트 / null : 전체)
- 조회시 모든 새알림표식 삭제

### GET /notifications/has-unread
- 새 알림 존재 여부 조회(앱 뱃지와 레드닷 표시에 사용)
- 새 알림이 하나라도 있으면 true, 아니면 false 반환

### DELETE /notifications/{id}/read
- 알림 삭제

### PATCH /notifications/{id}
- 알림 읽음 처리
- 알림탭에서 알림 클릭으로 직접 이동 시 호출
- 읽는 해당 알림에 새알림표식 제거

## 관련링크 (JIRA, Github, etc)
<!--
- 관련링크를 나열합니다.
-->

- #182 
